### PR TITLE
correctly enable multi-gpu

### DIFF
--- a/src/myvllm/engine/sequence.py
+++ b/src/myvllm/engine/sequence.py
@@ -97,10 +97,19 @@ class Sequence:
 
     def __setstate__(self, state):
         (
-            self.num_tokens, 
-            self.num_prompt_tokens, 
-            self.num_cached_tokens, 
+            self.num_tokens,
+            self.num_prompt_tokens,
+            self.num_cached_tokens,
             self.block_table,
             last_token_or_ids
         ) = state
-        self.token_ids = last_token_or_ids if self.num_completion_tokens == 0 else [last_token_or_ids]
+        # Check if this is prefill (num_completion_tokens == 0) or decode phase
+        num_completion_tokens = self.num_tokens - self.num_prompt_tokens
+        if num_completion_tokens == 0:
+            # Prefill: last_token_or_ids is the full token_ids list
+            self.token_ids = last_token_or_ids
+        else:
+            # Decode: last_token_or_ids is just the last token
+            self.token_ids = [last_token_or_ids]
+        # Restore last_token attribute
+        self.last_token = self.token_ids[-1] if self.token_ids else None

--- a/src/myvllm/models/qwen3.py
+++ b/src/myvllm/models/qwen3.py
@@ -28,11 +28,11 @@ class Qwen3Attention(nn.Module):
         self.num_heads = num_heads // self.tp_size
 
         self.total_num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        # self.num_kv_heads is per-GPU value (divided by tp_size)
         self.num_kv_heads = self.total_num_kv_heads // self.tp_size
 
         self.head_dim = head_dim if head_dim is not None else hidden_size // num_heads
         self.scale = scale
-        self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
 
         self.qkv_projection = QKVColumnParallelLinear(
             input_size=head_dim * self.total_num_heads,


### PR DESCRIPTION
# Summary of Changes
## Process Coordination 
llm_engine.py#L13-L22
Created worker_process() wrapper to properly manage worker initialization and event loop

## Synchronization
model_runner.py#L62-L81
Moved barrier and shared memory setup to after all model initialization
Added second barrier to prevent race condition in shared memory attachment

## Inter-Process Communication 
model_runner.py#L121
Fixed pickle serialization to flatten argument tuple structure
Fixed argument unpacking in the event loop

## Distributed Execution 
llm_engine.py#L53
Changed to use call() method to coordinate execution across both GPUs

## Sequence Serialization 
sequence.py#L98-L115
Fixed __setstate__ to properly restore last_token attribute after deserialization

## Clean Exit 
model_runner.py#L115-L116
Added check before destroying process group to prevent double-destruction error

## Row/Column Parallel Linear Layers 
linear.py#L195-L222
Fixed dimension calculations for proper tensor sharding across GPUs
Ensured all_reduce is called in RowParallelLinear.forward() when tp_size > 1

## QKV Linear Layer
linear.py#L151-L169
Issue: num_kv_heads was being overwritten incorrectly during initialization

## Embedding Layer - Vocab Padding
embedding_head.py
Issue: Vocabulary size wasn't divisible by tp_size, causing dimension mismatches
Fix: Added padding to make vocab size divisible, with proper handling in weight_loader() and forward()

## Performance
Prefill: ~7000-8600 tokens/sec
Decode: ~90-100 tokens/sec (for larger batches)

# To Test
Simply change world_size = 2 to enable multi-GPU


resolves #25 