### PR TITLE
Fix typo: rename 'shared' to 'shard' in linear.py

### DIFF
--- a/src/myvllm/layers/linear.py
+++ b/src/myvllm/layers/linear.py
@@ -144,8 +144,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         param_data = param_data.narrow(0, offset, shard_size)
         # shard the original full weight
         loaded_weights_start_index = self.tp_rank * shard_size
-        shared_weights = loaded_weights.narrow(0, loaded_weights_start_index, shard_size)
-        param_data.copy_(shared_weights)
+        shard_weights = loaded_weights.narrow(0, loaded_weights_start_index, shard_size)
+        param_data.copy_(shard_weights)
 
 
 class QKVColumnParallelLinear(ColumnParallelLinear):
@@ -190,9 +190,9 @@ class QKVColumnParallelLinear(ColumnParallelLinear):
         param_data = param_data.narrow(0, offset, shard_size)
         # shard the original full weight
         loaded_weights_start_index = self.tp_rank * shard_size
-        shared_weights = loaded_weights.narrow(0, loaded_weights_start_index, shard_size)
+        shard_weights = loaded_weights.narrow(0, loaded_weights_start_index, shard_size)
 
-        param_data.copy_(shared_weights)
+        param_data.copy_(shard_weights)
 
 
 class RowParallelLinear(LinearBase):


### PR DESCRIPTION
According to the code semantics, four occurrences of `shared_weights` in `linear.py` should be changed to `shard_weights`.

[linear.py#L147](https://github.com/Wenyueh/MinivLLM/blob/3b02aa529e6f8efff85558eedcb3bb1eacb9fa2c/src/myvllm/layers/linear.py#L147)
[linear.py#L148](https://github.com/Wenyueh/MinivLLM/blob/3b02aa529e6f8efff85558eedcb3bb1eacb9fa2c/src/myvllm/layers/linear.py#L148)
[linear.py#L193](https://github.com/Wenyueh/MinivLLM/blob/3b02aa529e6f8efff85558eedcb3bb1eacb9fa2c/src/myvllm/layers/linear.py#L193)
[linear.py#L195](https://github.com/Wenyueh/MinivLLM/blob/3b02aa529e6f8efff85558eedcb3bb1eacb9fa2c/src/myvllm/layers/linear.py#L195)