### PR TITLE
Fix: the error when the context exceeds 256 tokens

### DIFF
--- a/src/myvllm/engine/llm_engine.py
+++ b/src/myvllm/engine/llm_engine.py
@@ -63,6 +63,9 @@ class LLMEngine:
             return [], is_prefill
         # run the model
         outputs = self.model_runner.call("run", scheduled_sequences, is_prefill)
+        # Move outputs to CPU and convert them to a list
+        if outputs is not None:
+            outputs = outputs.cpu().tolist()
         # postprocess the outputs
         self.scheduler.postprocess(scheduled_sequences, outputs)
 


### PR DESCRIPTION
# Problem
When the sequence length reaches 256, the append function in block_manager.py will determine that the current block is full and attempt to call computehash to calculate the hash value for prefix caching. Computehash uses numpy internally, which does not support Tensor on GPU, resulting in an error.

# Solution
We need to move the tokens generated by the model from GPU to CPU in llm_engine. py, convert them into regular Python lists, and then pass them to the scheduler for processing.