### PR TITLE
[Optimize] Token parallel in paged attention kernel

### DIFF
--- a/HowToApproachvLLM.md
+++ b/HowToApproachvLLM.md
@@ -199,11 +199,10 @@ y = x.reshape(2, 3).T  # logically: [[1,4],[2,5],[3,6]]
 
 ---
 
-### 1.5 Attention Layer
+### 1.5 Attention Layer ✅
 
 Path: [attention.py](src/myvllm/layers/attention.py)
-
-Implement attention mechanism (preferably FlashAttention).
+Benchmark: [benchmark_decoding.py](benchmark_decoding.py)
 
 **Key Tensor Concepts:**
 - **stride()**: When a tensor is stored in memory, it's a contiguous 1D array. Stride tells you how many elements to skip to move to the next element along a dimension.
@@ -221,6 +220,182 @@ Implement attention mechanism (preferably FlashAttention).
 
 **Triton Kernel Note:**
 - When passing PyTorch tensor to Triton kernel, **Triton automatically extracts the pointer** (memory address) from the tensor
+
+---
+
+#### FlashAttention vs PagedAttention
+
+These are not two alternatives — they are **orthogonal**, and the decode kernel uses both:
+
+- **FlashAttention** is a *compute* technique: tile the sequence and merge each tile with an online softmax, so the `(seq_len, seq_len)` score matrix is never materialized. It solves memory traffic.
+- **PagedAttention** is a *storage* technique: keep the KV cache in fixed-size blocks and reach them through a per-sequence block table. It solves fragmentation.
+
+|  | Prefill | Decode |
+|---|---|---|
+| Query length | whole prompt (100s–1000s of tokens) | exactly **1** token per sequence |
+| Compute | tiled + online softmax (**flash**) | tiled + online softmax (**flash**) |
+| K/V source | the `k`, `v` just computed, packed varlen | the **paged** KV cache |
+| Bottleneck | compute (large matmuls) | memory (walk the whole cache for one token) |
+| Kernel | `flash_attention_prefill` | `paged_attention_decode` |
+
+So decode is *flash **and** paged*; in this repo prefill is flash only, because it reads K/V straight from the tensors it was handed instead of from the cache.
+
+Decode is where an inference engine spends most of its wall clock, so the rest of this section walks through the paged decode kernel step by step.
+
+---
+
+#### Step 1: Fix the KV cache layout
+
+```python
+k_cache: (num_blocks, block_size, num_kv_heads, head_dim)
+```
+
+The cache is a flat pool of fixed-size **blocks**. A sequence does not own a contiguous span of it — it owns a *list* of blocks that the `BlockManager` hands out from whatever is free. `block_size` is 256 in [main.py](main.py).
+
+Flattened, the element offset of one (block, slot, kv_head, dim) entry is:
+
+```python
+offset = (physical_block * block_size * num_kv_heads * head_dim   # skip whole blocks
+          + slot          * num_kv_heads * head_dim               # skip slots in this block
+          + kv_head       * head_dim                              # skip heads
+          + dim)
+```
+
+Keep this formula in mind — every bug in Step 7 is a wrong term in it.
+
+#### Step 2: Write new K/V into the cache
+
+`store_kvcache` launches a `(num_tokens, num_kv_heads)` grid. Each program copies one token's K and V for one head into the slot given by `slot_mapping[token]`, which the ModelRunner precomputes. A `slot_mapping` of `-1` means "skip this token".
+
+#### Step 3: Prefill — variable-length attention
+
+Sequences in a batch have different lengths, so they are packed end to end and delimited by `cu_seqlens` (cumulative lengths):
+
+```
+cu_seqlens = [0, 5, 12, 20]   ->   seq 0 = tokens 0..4, seq 1 = 5..11, seq 2 = 12..19
+```
+
+Grid is `(cdiv(max_seq_len, BLOCK_M), num_heads, num_seqs)`: one program per query block, per head, per sequence. Each program holds its Q block in registers and streams K/V blocks past it, updating the running softmax.
+
+#### Step 4: The online softmax recurrence
+
+Both kernels rely on it. Attention over a chunk `j` can be merged into a running result without ever holding all scores:
+
+```python
+m_new = max(m_old, max(qk_j))          # running max, for numerical stability
+alpha = exp(m_old - m_new)             # how much to shrink what we already had
+acc   = acc * alpha + sum(exp(qk_j - m_new) * V_j)
+l     = l   * alpha + sum(exp(qk_j - m_new))
+# after the last chunk:
+out   = acc / l
+```
+
+`m` exists only to stop `exp()` from overflowing; `l` is the softmax denominator accumulated so far.
+
+#### Step 5: Decode — walking the paged cache
+
+Grid is `(batch_size, num_heads)`: one program per (sequence, query head). Each program loads its single query vector, then walks that sequence's KV cache in chunks of `BLOCK_N` tokens, applying the recurrence above.
+
+The hard part is that a chunk of *logical* tokens is scattered across *physical* blocks. Resolving one logical token takes **two divisions**:
+
+```python
+logical_block  = t // block_size                       # which block of this sequence
+slot           = t %  block_size                       # where inside that block
+physical_block = block_tables[seq, logical_block]      # the indirection
+```
+
+For GQA, the query head also has to be mapped to its KV head:
+
+```python
+kv_head_idx = head_idx // (num_heads // num_kv_heads)
+```
+
+#### Step 6: How to walk a chunk
+
+Three ways to fill in `physical_block` and `slot` for a chunk of `BLOCK_N` tokens:
+
+**(a) One token at a time** — correct but slow. `for i in range(BLOCK_N)` unrolls into `BLOCK_N` scalar loads plus `BLOCK_N` `tl.where` merges, leaving the whole SIMD width idle.
+
+**(b) One block-table lookup per chunk** — fast, but only valid when a chunk cannot straddle two blocks (`block_size % BLOCK_N == 0`), and it still needs `slot = t % block_size`.
+
+**(c) Gather the block table per token** — fast *and* general. Each lane resolves its own token, so a chunk may span any number of blocks:
+
+```python
+offs_n        = token_start + tl.arange(0, BLOCK_N)
+logical_block = offs_n // block_size
+offs_in_block = offs_n %  block_size
+
+in_range = (offs_n < context_len) & (logical_block < max_num_blocks)
+
+# one block-table entry per token, not per chunk
+physical_block = tl.load(block_tables_ptr + batch_idx * max_num_blocks + logical_block,
+                         mask=in_range, other=-1)
+valid = in_range & (physical_block != -1)
+
+# masked lanes still take part in address arithmetic: give them block 0
+physical_block = tl.where(valid, physical_block, 0).to(tl.int64)
+
+kv_offset = (physical_block[None, :] * (block_size * num_kv_heads * head_dim)
+             + offs_in_block[None, :] * (num_kv_heads * head_dim)
+             + kv_head_idx * head_dim
+             + offs_d[:, None])
+```
+
+K and V share `kv_offset`, so the block table is gathered once per chunk instead of twice.
+
+#### Step 7: Pitfalls
+
+1. **Global token index used as the within-block offset.** `physical_block * block_size` already moves the pointer to the start of the block, so the next term must be `t % block_size`, not `t`. Using `t` reads past the block into whatever sequence owns the following blocks — and far enough past the end of the cache it becomes an illegal memory access. It looks correct as long as every test sequence fits in a single block.
+2. **One block-table lookup per chunk.** Only valid if a chunk fits inside a block. With `block_size=16` and `BLOCK_N=64` a chunk spans 4 blocks and 3 of them are never looked up.
+3. **Masked lanes still compute addresses.** `tl.load(..., mask=...)` suppresses the *load*, not the address arithmetic. A `-1` left in `physical_block` produces a negative offset, so clamp invalid lanes to block 0.
+4. **int32 overflow.** At 256×8×128 = 262144 elements per block, `physical_block * block_size * num_kv_heads * head_dim` overflows int32 past ~8192 blocks. Cast the block index to `int64`.
+5. **Identity block tables in tests.** If a test builds `block_tables = torch.arange(...)`, logical order equals physical order and *every* bug above disappears. Use a shuffled mapping — that is what a real `BlockManager` produces.
+6. **Losing the bounds check.** `logical_block < max_num_blocks` guards against reading past the end of the block table.
+
+---
+
+#### Benchmark results
+
+[benchmark_decoding.py](benchmark_decoding.py) compares four implementations on identical inputs. Every one is checked against a float32 reference *before* it is timed — a kernel that is fast because it reads the wrong memory shows up as `NO` in the correct column rather than as a speedup.
+
+Qwen3-0.6B attention shape (`num_heads=16, num_kv_heads=8, head_dim=128, block_size=256`), fp16, one A6000. Time per call in ms, speedup relative to Naive PyTorch:
+
+| batch | seq_len | Naive PyTorch | Fast PyTorch | Triton per-token | Triton chunked |
+|------:|--------:|--------------:|-------------:|-----------------:|---------------:|
+| 1 | 128 | 0.385 (1.0x) | 0.778 (0.5x) | 0.088 (4.4x) | **0.028 (14.0x)** |
+| 1 | 512 | 0.445 (1.0x) | 0.977 (0.5x) | 0.340 (1.3x) | **0.026 (16.8x)** |
+| 1 | 2048 | 0.735 (1.0x) | 0.818 (0.9x) | 1.939 (0.4x) | **0.098 (7.5x)** |
+| 8 | 128 | 0.833 (1.0x) | 3.780 (0.2x) | 0.084 (10.0x) | **0.026 (31.8x)** |
+| 8 | 512 | 1.232 (1.0x) | 4.029 (0.3x) | 0.465 (2.7x) | **0.040 (31.1x)** |
+| 8 | 2048 | 4.297 (1.0x) | 5.042 (0.9x) | 1.848 (2.3x) | **0.127 (33.9x)** |
+| 32 | 128 | 2.272 (1.0x) | 14.410 (0.2x) | 0.127 (17.9x) | **0.034 (67.5x)** |
+| 32 | 512 | 4.574 (1.0x) | 15.147 (0.3x) | 0.518 (8.8x) | **0.130 (35.1x)** |
+| 32 | 2048 | 16.849 (1.0x) | 19.681 (0.9x) | 1.975 (8.5x) | **0.493 (34.2x)** |
+
+Reading the table:
+
+- **Chunked beats per-token by 3.1x–21.3x**, and the gap widens with context length. At `seq_len=2048` the per-token kernel is *slower than PyTorch*: its cost tracks token count rather than memory traffic.
+- **"Fast PyTorch" is usually the slowest.** Its vectorised gather materializes a dense `(batch, max_ctx, kv_heads, head_dim)` copy of the cache, and at batch 32 that allocation dominates. Padding to a dense tensor is exactly what paged attention exists to avoid.
+- **The Triton kernels win most at large batch**, where the `(batch, num_heads)` grid finally has enough programs to fill the GPU.
+- **Batch 1 is the weak spot**: only 16 programs, so most of the GPU sits idle. Splitting the KV sequence across programs (flash-decoding) is the next optimization — the grid becomes `(batch, heads, kv_splits)` and a second kernel merges each split's `(m, l, acc)`.
+
+The generic per-token gather costs nothing measurable over the block-aligned version — the kernel is memory-bound — and it works for any `block_size`:
+
+| block_size | Triton per-token | Triton chunked | speedup |
+|-----------:|-----------------:|---------------:|--------:|
+| 16 | 0.978 ms | 0.056 ms | 17.5x |
+| 32 | 0.979 ms | 0.056 ms | 17.5x |
+| 100 | 1.014 ms | 0.057 ms | 17.8x |
+| 256 | 0.955 ms | 0.053 ms | 18.0x |
+
+(batch 4, seq_len 1000. `block_size=100` is deliberately neither a power of two nor a multiple of `BLOCK_N`.)
+
+Running it:
+
+```bash
+uv run python benchmark_decoding.py                                  # default sweep
+uv run python benchmark_decoding.py --block-size 16 --seq-lens 1000  # single config
+```
 
 ---
 

--- a/HowToApproachvLLM_zh.md
+++ b/HowToApproachvLLM_zh.md
@@ -201,11 +201,10 @@ y = x.reshape(2, 3).T   # 逻辑视图: [[1,4],[2,5],[3,6]]
 
 ---
 
-### 1.5 注意力层（Attention Layer）
+### 1.5 注意力层（Attention Layer）✅
 
 具体实现：[attention.py](src/myvllm/layers/attention.py)
-
-实现注意力机制（最好使用 FlashAttention）。
+性能测试：[benchmark_decoding.py](benchmark_decoding.py)
 
 **关键张量概念（Key Tensor Concepts）：**
 - **`stride()`**：当一个张量存储在内存中时，本质上是一个连续的一维数组。stride 用来描述：沿着某个维度移动到“下一个元素”时，需要在底层内存中跳过多少个元素。
@@ -223,6 +222,182 @@ y = x.reshape(2, 3).T   # 逻辑视图: [[1,4],[2,5],[3,6]]
 
 **Triton Kernel 备注：**
 - 当将 PyTorch 张量传给 Triton kernel 时，**Triton 会自动从张量中提取指针**（内存地址）
+
+---
+
+#### FlashAttention 与 PagedAttention
+
+这两者不是二选一的关系，而是**正交的两个维度**，decode kernel 两者都用：
+
+- **FlashAttention** 是**计算**技术：把序列分块，用 online softmax 逐块合并，从而不需要 materialize `(seq_len, seq_len)` 的分数矩阵。解决的是访存开销。
+- **PagedAttention** 是**存储**技术：KV cache 按固定大小的块存放，通过每个序列各自的 block table 间接寻址。解决的是显存碎片化。
+
+|  | Prefill | Decode |
+|---|---|---|
+| Query 长度 | 整个 prompt（数百到数千 token） | 每个序列恰好 **1** 个 token |
+| 计算方式 | 分块 + online softmax（**flash**） | 分块 + online softmax（**flash**） |
+| K/V 来源 | 刚算出的 `k`、`v`，varlen 打包 | **paged** KV cache |
+| 瓶颈 | 计算（大矩阵乘） | 访存（为产出 1 个 token 要遍历整个 cache） |
+| Kernel | `flash_attention_prefill` | `paged_attention_decode` |
+
+所以 decode 是 *flash **加** paged*；本仓库的 prefill 只用了 flash，因为它直接读传进来的张量，不读 cache。
+
+推理引擎的绝大部分时间花在 decode 上，因此本节剩余部分逐步讲解 paged decode kernel。
+
+---
+
+#### Step 1：确定 KV cache 的内存布局
+
+```python
+k_cache: (num_blocks, block_size, num_kv_heads, head_dim)
+```
+
+cache 是一个由固定大小**块（block）**组成的扁平池。一个序列并不占据其中连续的一段，而是持有一个**块列表** —— `BlockManager` 从空闲块里任意分配。[main.py](main.py) 中 `block_size` 为 256。
+
+展平之后，某个 (block, slot, kv_head, dim) 元素的偏移量为：
+
+```python
+offset = (physical_block * block_size * num_kv_heads * head_dim   # 跳过前面整块
+          + slot          * num_kv_heads * head_dim               # 跳过块内前面的槽位
+          + kv_head       * head_dim                              # 跳过前面的头
+          + dim)
+```
+
+记住这个公式 —— Step 7 里的每个 bug 都是这个公式中某一项写错了。
+
+#### Step 2：把新的 K/V 写入 cache
+
+`store_kvcache` 启动 `(num_tokens, num_kv_heads)` 的 grid。每个 program 把一个 token 在一个头上的 K 和 V 拷贝到 `slot_mapping[token]` 指定的槽位，该映射由 ModelRunner 预先算好。`slot_mapping` 为 `-1` 表示跳过该 token。
+
+#### Step 3：Prefill —— 变长注意力
+
+同一批次内的序列长度不同，因此它们被首尾拼接，用 `cu_seqlens`（累积长度）划分边界：
+
+```
+cu_seqlens = [0, 5, 12, 20]   ->   seq 0 = tokens 0..4, seq 1 = 5..11, seq 2 = 12..19
+```
+
+grid 为 `(cdiv(max_seq_len, BLOCK_M), num_heads, num_seqs)`：每个 program 负责一个序列、一个头、一个 query 分块。program 把自己的 Q 块常驻寄存器，让 K/V 块流经它，并不断更新 running softmax。
+
+#### Step 4：Online softmax 递推
+
+两个 kernel 都依赖它。第 `j` 块的注意力结果可以合并进已有结果，全程不需要持有所有分数：
+
+```python
+m_new = max(m_old, max(qk_j))          # running max，保证数值稳定
+alpha = exp(m_old - m_new)             # 已累积部分需要缩放的比例
+acc   = acc * alpha + sum(exp(qk_j - m_new) * V_j)
+l     = l   * alpha + sum(exp(qk_j - m_new))
+# 最后一块处理完之后：
+out   = acc / l
+```
+
+`m` 的唯一作用是防止 `exp()` 溢出；`l` 是到目前为止累积的 softmax 分母。
+
+#### Step 5：Decode —— 遍历 paged cache
+
+grid 为 `(batch_size, num_heads)`：每个 program 负责一个（序列，query 头）组合。program 载入它那一个 query 向量，然后以 `BLOCK_N` 个 token 为一块遍历该序列的 KV cache，套用上面的递推。
+
+难点在于：一块**逻辑上**连续的 token，在**物理上**散落在不同的块里。解析一个逻辑 token 需要**两次除法**：
+
+```python
+logical_block  = t // block_size                       # 属于本序列的第几块
+slot           = t %  block_size                       # 在该块内的第几个位置
+physical_block = block_tables[seq, logical_block]      # 间接寻址
+```
+
+对 GQA 而言，还需要把 query 头映射到对应的 KV 头：
+
+```python
+kv_head_idx = head_idx // (num_heads // num_kv_heads)
+```
+
+#### Step 6：如何遍历一个 chunk
+
+为一块 `BLOCK_N` 个 token 填出 `physical_block` 和 `slot`，有三种写法：
+
+**(a) 逐 token 处理** —— 正确但慢。`for i in range(BLOCK_N)` 会展开成 `BLOCK_N` 次标量加载再加 `BLOCK_N` 次 `tl.where` 合并，整个 SIMD 宽度都在闲置。
+
+**(b) 每个 chunk 查一次 block table** —— 快，但仅当一个 chunk 不会跨越两个块时才成立（`block_size % BLOCK_N == 0`），而且仍然需要 `slot = t % block_size`。
+
+**(c) 逐 token gather block table** —— 既快又通用。每条 lane 解析自己的 token，因此一个 chunk 可以跨越任意多个块：
+
+```python
+offs_n        = token_start + tl.arange(0, BLOCK_N)
+logical_block = offs_n // block_size
+offs_in_block = offs_n %  block_size
+
+in_range = (offs_n < context_len) & (logical_block < max_num_blocks)
+
+# 每个 token 一个 block table 条目，而不是每个 chunk 一个
+physical_block = tl.load(block_tables_ptr + batch_idx * max_num_blocks + logical_block,
+                         mask=in_range, other=-1)
+valid = in_range & (physical_block != -1)
+
+# 被 mask 掉的 lane 仍会参与地址运算：把它们指向第 0 块
+physical_block = tl.where(valid, physical_block, 0).to(tl.int64)
+
+kv_offset = (physical_block[None, :] * (block_size * num_kv_heads * head_dim)
+             + offs_in_block[None, :] * (num_kv_heads * head_dim)
+             + kv_head_idx * head_dim
+             + offs_d[:, None])
+```
+
+K 和 V 共用 `kv_offset`，因此每个 chunk 只 gather 一次 block table，而不是两次。
+
+#### Step 7：容易踩的坑
+
+1. **把全局 token 下标当成块内偏移。** `physical_block * block_size` 已经把指针移到了该块的起始位置，所以下一项必须是 `t % block_size` 而不是 `t`。用 `t` 会越过块尾读到后续块所属的其他序列的数据 —— 越界得足够远时会直接变成非法内存访问。只要测试用的序列都能装进单个块，这个错误就看不出来。
+2. **每个 chunk 只查一次 block table。** 只有当 chunk 能装进一个块时才成立。`block_size=16` 配 `BLOCK_N=64` 时，一个 chunk 横跨 4 个块，其中 3 个从未被查过。
+3. **被 mask 掉的 lane 仍然会计算地址。** `tl.load(..., mask=...)` 抑制的是**加载**，不是地址运算。`physical_block` 中残留的 `-1` 会算出负偏移，因此要把无效 lane 钳到第 0 块。
+4. **int32 溢出。** 每块 256×8×128 = 262144 个元素，`physical_block * block_size * num_kv_heads * head_dim` 在块数超过约 8192 时会溢出 int32。需要把块下标转成 `int64`。
+5. **测试里用恒等的 block table。** 如果测试用 `block_tables = torch.arange(...)` 构造，逻辑顺序就等于物理顺序，上面**所有** bug 都会消失。应当使用打乱的映射 —— 真实的 `BlockManager` 产出的就是这样。
+6. **丢掉边界检查。** `logical_block < max_num_blocks` 用于防止读越 block table 的尾部。
+
+---
+
+#### 性能测试结果
+
+[benchmark_decoding.py](benchmark_decoding.py) 在完全相同的输入上对比四种实现。每种实现在计时**之前**都会先和 float32 参考结果比对 —— 一个因为读错内存而“变快”的 kernel，会在 correct 列显示 `NO`，而不是显示成加速。
+
+Qwen3-0.6B 的注意力形状（`num_heads=16, num_kv_heads=8, head_dim=128, block_size=256`），fp16，单张 A6000。单次调用耗时（ms），加速比相对 Naive PyTorch：
+
+| batch | seq_len | Naive PyTorch | Fast PyTorch | Triton 逐 token | Triton 分块 |
+|------:|--------:|--------------:|-------------:|----------------:|------------:|
+| 1 | 128 | 0.385 (1.0x) | 0.778 (0.5x) | 0.088 (4.4x) | **0.028 (14.0x)** |
+| 1 | 512 | 0.445 (1.0x) | 0.977 (0.5x) | 0.340 (1.3x) | **0.026 (16.8x)** |
+| 1 | 2048 | 0.735 (1.0x) | 0.818 (0.9x) | 1.939 (0.4x) | **0.098 (7.5x)** |
+| 8 | 128 | 0.833 (1.0x) | 3.780 (0.2x) | 0.084 (10.0x) | **0.026 (31.8x)** |
+| 8 | 512 | 1.232 (1.0x) | 4.029 (0.3x) | 0.465 (2.7x) | **0.040 (31.1x)** |
+| 8 | 2048 | 4.297 (1.0x) | 5.042 (0.9x) | 1.848 (2.3x) | **0.127 (33.9x)** |
+| 32 | 128 | 2.272 (1.0x) | 14.410 (0.2x) | 0.127 (17.9x) | **0.034 (67.5x)** |
+| 32 | 512 | 4.574 (1.0x) | 15.147 (0.3x) | 0.518 (8.8x) | **0.130 (35.1x)** |
+| 32 | 2048 | 16.849 (1.0x) | 19.681 (0.9x) | 1.975 (8.5x) | **0.493 (34.2x)** |
+
+如何解读这张表：
+
+- **分块比逐 token 快 3.1x–21.3x**，且上下文越长差距越大。`seq_len=2048` 时逐 token 版本**比 PyTorch 还慢** —— 它的开销取决于 token 数量，而不是访存量。
+- **“Fast PyTorch”往往是最慢的。** 它的向量化 gather 会 materialize 一份稠密的 `(batch, max_ctx, kv_heads, head_dim)` cache 副本，batch 32 时这次分配就成了主要开销。而“填充成稠密张量”恰恰是 paged attention 要避免的事情。
+- **Triton kernel 在大 batch 下优势最明显**，此时 `(batch, num_heads)` 的 grid 才有足够多的 program 填满 GPU。
+- **batch 1 是短板**：只有 16 个 program，GPU 大部分处于空闲。把 KV 序列拆分到多个 program（flash-decoding）是下一步优化 —— grid 变成 `(batch, heads, kv_splits)`，再用第二个 kernel 合并各 split 的 `(m, l, acc)`。
+
+通用的逐 token gather 相比块对齐版本没有可测量的开销（kernel 是访存受限的），而且对任意 `block_size` 都成立：
+
+| block_size | Triton 逐 token | Triton 分块 | 加速比 |
+|-----------:|----------------:|------------:|-------:|
+| 16 | 0.978 ms | 0.056 ms | 17.5x |
+| 32 | 0.979 ms | 0.056 ms | 17.5x |
+| 100 | 1.014 ms | 0.057 ms | 17.8x |
+| 256 | 0.955 ms | 0.053 ms | 18.0x |
+
+（batch 4，seq_len 1000。`block_size=100` 是刻意选的：既不是 2 的幂，也不是 `BLOCK_N` 的整数倍。）
+
+运行方式：
+
+```bash
+uv run python benchmark_decoding.py                                  # 默认扫描
+uv run python benchmark_decoding.py --block-size 16 --seq-lens 1000  # 单个配置
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./assets/minivllm.png" alt="图片描述" width="50%" height="50%">
+  <img src="./assets/minivllm.png" alt="MinivLLM" width="50%" height="50%">
 </p>
 
 <p align="center">

--- a/benchmark_decoding.py
+++ b/benchmark_decoding.py
@@ -1,10 +1,29 @@
+"""Paged-attention decode benchmark.
+
+Compares four implementations on identical inputs:
+
+  Naive PyTorch   gathers K/V block by block in a Python loop, then dense attention
+  Fast PyTorch    vectorised gather + batched matmul
+  Triton (old)    one scalar iteration per token inside each chunk
+  Triton (new)    whole chunk loaded as a single masked vector op
+
+Every implementation is checked against a float32 reference before it is timed, so
+a kernel that is fast because it reads the wrong memory shows up as NO in the
+correct column rather than as a speedup.
+"""
+
+import argparse
 import torch
-import time
-import triton 
+import triton
 import triton.language as tl
 
+
+# =============================================================================
+# Triton (old): scalar per-token loop inside each chunk
+# =============================================================================
+
 @triton.jit
-def paged_attention_decode_kernel(
+def paged_attention_decode_kernel_old(
     output_ptr,
     query_ptr,
     k_cache_ptr,
@@ -19,119 +38,234 @@ def paged_attention_decode_kernel(
     max_num_blocks: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    """Optimized paged attention kernel for decode phase."""
+    """Paged attention decode kernel. Processes KV cache in chunks.
+
+    Each chunk is walked one token at a time, so the block table is looked up per
+    token and the within-block offset is token_idx % block_size.
+    """
     batch_idx = tl.program_id(0)
     head_idx = tl.program_id(1)
-    
+
     kv_head_idx = head_idx // (num_heads // num_kv_heads)
     context_len = tl.load(context_lens_ptr + batch_idx)
-    
+
     offs_d = tl.arange(0, head_dim)
     q_offset = batch_idx * num_heads * head_dim + head_idx * head_dim + offs_d
     q = tl.load(query_ptr + q_offset)
-    
+
     acc = tl.zeros([head_dim], dtype=tl.float32)
     l_i = 0.0
     m_i = -1e10
-    
+
     max_chunks = tl.cdiv(max_num_blocks * block_size, BLOCK_N)
-    
+
     for chunk_idx in range(max_chunks):
         token_start = chunk_idx * BLOCK_N
-        
+
         if token_start < context_len:
             offs_n = token_start + tl.arange(0, BLOCK_N)
             mask_n = offs_n < context_len
-            
+
             qk = tl.zeros([BLOCK_N], dtype=tl.float32) - 1e10
-            
+
             for i in range(BLOCK_N):
                 token_idx = token_start + i
                 if token_idx < context_len:
                     block_num = token_idx // block_size
                     block_offset = token_idx % block_size
-                    
+
                     if block_num < max_num_blocks:
                         block_table_offset = batch_idx * max_num_blocks + block_num
                         physical_block_idx = tl.load(block_tables_ptr + block_table_offset)
-                        
+
                         if physical_block_idx != -1:
                             k_offset = (physical_block_idx * block_size * num_kv_heads * head_dim +
-                                       block_offset * num_kv_heads * head_dim +
-                                       kv_head_idx * head_dim + offs_d)
+                                        block_offset * num_kv_heads * head_dim +
+                                        kv_head_idx * head_dim + offs_d)
                             k_vec = tl.load(k_cache_ptr + k_offset)
-                            
+
                             score = tl.sum(q * k_vec) * scale
                             mask_i = tl.arange(0, BLOCK_N) == i
                             qk = tl.where(mask_i, score, qk)
-            
+
             qk = tl.where(mask_n, qk, -1e10)
-            
+
             m_ij = tl.max(qk)
             m_i_new = tl.maximum(m_i, m_ij)
             alpha = tl.exp(m_i - m_i_new)
             p = tl.exp(qk - m_i_new)
-            
+
             acc = acc * alpha
             l_i = l_i * alpha
-            
+
             for i in range(BLOCK_N):
                 token_idx = token_start + i
                 if token_idx < context_len:
                     block_num = token_idx // block_size
                     block_offset = token_idx % block_size
-                    
+
                     if block_num < max_num_blocks:
                         block_table_offset = batch_idx * max_num_blocks + block_num
                         physical_block_idx = tl.load(block_tables_ptr + block_table_offset)
-                        
+
                         if physical_block_idx != -1:
                             v_offset = (physical_block_idx * block_size * num_kv_heads * head_dim +
-                                       block_offset * num_kv_heads * head_dim +
-                                       kv_head_idx * head_dim + offs_d)
+                                        block_offset * num_kv_heads * head_dim +
+                                        kv_head_idx * head_dim + offs_d)
                             v_vec = tl.load(v_cache_ptr + v_offset)
-                            
+
                             mask_i = tl.arange(0, BLOCK_N) == i
                             weight = tl.sum(tl.where(mask_i, p, 0.0))
-                            
+
                             acc = acc + weight * v_vec
                             l_i = l_i + weight
-            
+
             m_i = m_i_new
-    
+
     output = acc / l_i
     output_offset = batch_idx * num_heads * head_dim + head_idx * head_dim + offs_d
     tl.store(output_ptr + output_offset, output)
 
 
-def paged_attention_decode_triton(
-    query: torch.Tensor,
-    k_cache: torch.Tensor,
-    v_cache: torch.Tensor,
-    block_tables: torch.Tensor,
-    context_lens: torch.Tensor,
-    scale: float,
-    num_heads: int,
-    num_kv_heads: int,
-    head_dim: int,
-    block_size: int
-) -> torch.Tensor:
-    batch_size = query.shape[0]
-    max_num_blocks = block_tables.shape[1]
-    query = query.contiguous()
-    output = torch.empty_like(query)
-    
-    BLOCK_N = 64 if head_dim <= 128 else 32
-    grid = (batch_size, num_heads)
-    
-    paged_attention_decode_kernel[grid](
-        output, query, k_cache, v_cache, block_tables, context_lens,
-        scale=scale, num_heads=num_heads, num_kv_heads=num_kv_heads,
-        head_dim=head_dim, block_size=block_size, 
-        max_num_blocks=max_num_blocks, BLOCK_N=BLOCK_N,
-    )
-    return output
+# =============================================================================
+# Triton (new): whole chunk loaded as one vector op
+# =============================================================================
 
+@triton.jit
+def paged_attention_decode_kernel_new(
+    output_ptr,
+    query_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    block_tables_ptr,
+    context_lens_ptr,
+    scale: tl.constexpr,
+    num_heads: tl.constexpr,
+    num_kv_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_size: tl.constexpr,
+    max_num_blocks: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Paged attention decode kernel with the whole chunk loaded at once.
+
+    The block table is gathered per token rather than per chunk, so a chunk may
+    straddle any number of blocks and no relation between BLOCK_N and block_size
+    is assumed. Each lane resolves its own token independently:
+
+        token t  ->  block_tables[batch, t // block_size], slot t % block_size
+
+    K/V for the whole chunk then come from one masked gather each.
+    """
+    batch_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    kv_head_idx = head_idx // (num_heads // num_kv_heads)
+    context_len = tl.load(context_lens_ptr + batch_idx)
+
+    offs_d = tl.arange(0, head_dim)
+    q_offset = batch_idx * num_heads * head_dim + head_idx * head_dim + offs_d
+    q = tl.load(query_ptr + q_offset)
+
+    acc = tl.zeros([head_dim], dtype=tl.float32)
+    l_i = 0.0
+    m_i = -1e10
+
+    max_chunks = tl.cdiv(max_num_blocks * block_size, BLOCK_N)
+
+    for chunk_idx in range(max_chunks):
+        token_start = chunk_idx * BLOCK_N
+
+        if token_start < context_len:
+            offs_n = token_start + tl.arange(0, BLOCK_N)
+            logical_block = offs_n // block_size
+            # physical_block * block_size already moves the base pointer to the
+            # start of the block, so what is added is the offset *within* the
+            # block, not the global token index.
+            offs_in_block = offs_n % block_size
+
+            in_range = (offs_n < context_len) & (logical_block < max_num_blocks)
+
+            # One block-table entry per token: a chunk is free to span several
+            # blocks, and those blocks need not be adjacent in the cache.
+            physical_block = tl.load(
+                block_tables_ptr + batch_idx * max_num_blocks + logical_block,
+                mask=in_range, other=-1)
+            valid = in_range & (physical_block != -1)
+            # Masked-out lanes still take part in the address arithmetic, so give
+            # them block 0 to keep every computed offset inside the cache.
+            physical_block = tl.where(valid, physical_block, 0).to(tl.int64)
+
+            kv_offset = (physical_block[None, :] * (block_size * num_kv_heads * head_dim)
+                         + offs_in_block[None, :] * (num_kv_heads * head_dim)
+                         + kv_head_idx * head_dim
+                         + offs_d[:, None])
+
+            k = tl.load(k_cache_ptr + kv_offset, mask=valid[None, :], other=0.0)
+            k = tl.cast(k, tl.float32)
+            score = tl.sum(q[:, None] * k, axis=0) * scale
+            qk = tl.where(valid, score, -1e10)
+
+            m_ij = tl.max(qk)
+            m_i_new = tl.maximum(m_i, m_ij)
+            alpha = tl.exp(m_i - m_i_new)
+            p = tl.exp(qk - m_i_new)
+
+            acc = acc * alpha
+            l_i = l_i * alpha
+
+            v = tl.load(v_cache_ptr + kv_offset, mask=valid[None, :], other=0.0)
+            v = tl.cast(v, tl.float32)
+            weight = tl.where(valid, p, 0.0)
+            acc = acc + tl.sum(weight[None, :] * v, axis=1)
+            l_i = l_i + tl.sum(weight)
+
+            m_i = m_i_new
+
+    output = acc / l_i
+    output_offset = batch_idx * num_heads * head_dim + head_idx * head_dim + offs_d
+    tl.store(output_ptr + output_offset, output)
+
+
+def _make_triton_launcher(kernel):
+    """Wrap a decode kernel behind a common signature."""
+    def launch(
+        query: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        block_tables: torch.Tensor,
+        context_lens: torch.Tensor,
+        scale: float,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        block_size: int,
+    ) -> torch.Tensor:
+        batch_size = query.shape[0]
+        max_num_blocks = block_tables.shape[1]
+        query = query.contiguous()
+        output = torch.empty_like(query)
+
+        BLOCK_N = 64 if head_dim <= 128 else 32
+        grid = (batch_size, num_heads)
+
+        kernel[grid](
+            output, query, k_cache, v_cache, block_tables, context_lens,
+            scale=scale, num_heads=num_heads, num_kv_heads=num_kv_heads,
+            head_dim=head_dim, block_size=block_size,
+            max_num_blocks=max_num_blocks, BLOCK_N=BLOCK_N,
+        )
+        return output
+    return launch
+
+
+paged_attention_decode_triton_old = _make_triton_launcher(paged_attention_decode_kernel_old)
+paged_attention_decode_triton_new = _make_triton_launcher(paged_attention_decode_kernel_new)
+
+
+# =============================================================================
+# PyTorch implementations
+# =============================================================================
 
 def decode_torch_optimized(
     q: torch.Tensor,
@@ -148,44 +282,42 @@ def decode_torch_optimized(
     batch_size = q.shape[0]
     device = q.device
     dtype = q.dtype
-    
+
     max_context_len = context_lens.max().item()
-    
+
     padded_k = torch.zeros(batch_size, max_context_len, num_kv_heads, head_dim, device=device, dtype=dtype)
     padded_v = torch.zeros(batch_size, max_context_len, num_kv_heads, head_dim, device=device, dtype=dtype)
-    
+
     for i in range(batch_size):
         seq_len = context_lens[i].item()
-        num_blocks_needed = (seq_len + block_size - 1) // block_size
-        
-        valid_blocks = block_tables[i, :num_blocks_needed]
-        valid_blocks = valid_blocks[valid_blocks != -1]
-        
-        if len(valid_blocks) > 0:
-            gathered_k = k_cache[valid_blocks].reshape(-1, num_kv_heads, head_dim)[:seq_len]
-            gathered_v = v_cache[valid_blocks].reshape(-1, num_kv_heads, head_dim)[:seq_len]
-            
-            padded_k[i, :seq_len] = gathered_k
-            padded_v[i, :seq_len] = gathered_v
-    
+        # Gather through the block table: logical token t lives at
+        # (block_tables[i, t // block_size], t % block_size).
+        idx = torch.arange(seq_len, device=device)
+        phys = block_tables[i][idx // block_size].long()
+        off = idx % block_size
+        valid = phys != -1
+
+        padded_k[i, :seq_len][valid] = k_cache[phys[valid], off[valid]]
+        padded_v[i, :seq_len][valid] = v_cache[phys[valid], off[valid]]
+
     if num_kv_heads != num_heads:
         num_groups = num_heads // num_kv_heads
         padded_k = padded_k.repeat_interleave(num_groups, dim=2)
         padded_v = padded_v.repeat_interleave(num_groups, dim=2)
-    
+
     q = q.unsqueeze(2)
     padded_k = padded_k.transpose(1, 2)
     padded_v = padded_v.transpose(1, 2)
-    
+
     attn_scores = torch.matmul(q, padded_k.transpose(-2, -1)) * scale
-    
+
     mask = torch.arange(max_context_len, device=device)[None, :] < context_lens[:, None]
     mask = mask[:, None, None, :]
     attn_scores = attn_scores.masked_fill(~mask, float('-inf'))
-    
+
     attn_probs = torch.softmax(attn_scores, dim=-1)
     output = torch.matmul(attn_probs, padded_v).squeeze(2)
-    
+
     return output
 
 
@@ -208,167 +340,203 @@ def naive_decode_attention(
     batch_size = q.shape[0]
     device = q.device
     dtype = q.dtype
-    
+
     max_context_len = context_lens.max().item()
-    
+
     # Gather K, V into full sequences (inefficient for large contexts)
-    all_k = []
-    all_v = []
-    
-    for i in range(batch_size):
-        seq_len = context_lens[i].item()
-        num_blocks_needed = (seq_len + block_size - 1) // block_size
-        
-        seq_k_list = []
-        seq_v_list = []
-        for block_idx in range(num_blocks_needed):
-            block_id = block_tables[i, block_idx].item()
-            if block_id == -1:
-                break
-            seq_k_list.append(k_cache[block_id])
-            seq_v_list.append(v_cache[block_id])
-        
-        if len(seq_k_list) > 0:
-            seq_k = torch.cat(seq_k_list, dim=0)[:seq_len]
-            seq_v = torch.cat(seq_v_list, dim=0)[:seq_len]
-            all_k.append(seq_k)
-            all_v.append(seq_v)
-    
-    # Pad sequences
     padded_k = torch.zeros(batch_size, max_context_len, num_kv_heads, head_dim,
                            device=device, dtype=dtype)
     padded_v = torch.zeros(batch_size, max_context_len, num_kv_heads, head_dim,
                            device=device, dtype=dtype)
-    
-    for i, (k_seq, v_seq) in enumerate(zip(all_k, all_v)):
-        seq_len = len(k_seq)
-        padded_k[i, :seq_len] = k_seq
-        padded_v[i, :seq_len] = v_seq
-    
+
+    for i in range(batch_size):
+        seq_len = context_lens[i].item()
+        num_blocks_needed = (seq_len + block_size - 1) // block_size
+
+        for block_idx in range(num_blocks_needed):
+            block_id = block_tables[i, block_idx].item()
+            if block_id == -1:
+                break
+            start = block_idx * block_size
+            end = min(start + block_size, seq_len)
+            padded_k[i, start:end] = k_cache[block_id, :end - start]
+            padded_v[i, start:end] = v_cache[block_id, :end - start]
+
     # GQA
     if num_kv_heads != num_heads:
         num_groups = num_heads // num_kv_heads
         padded_k = padded_k.repeat_interleave(num_groups, dim=2)
         padded_v = padded_v.repeat_interleave(num_groups, dim=2)
-    
+
     # Reshape and compute attention
     q = q.unsqueeze(2)  # (B, H, 1, D)
     padded_k = padded_k.transpose(1, 2)  # (B, H, N, D)
     padded_v = padded_v.transpose(1, 2)  # (B, H, N, D)
-    
+
     # This is the inefficient part - materializes full attention matrix
     attn_scores = torch.matmul(q, padded_k.transpose(-2, -1)) * scale
-    
+
     mask = torch.arange(max_context_len, device=device)[None, :] < context_lens[:, None]
     mask = mask[:, None, None, :]
     attn_scores = attn_scores.masked_fill(~mask, float('-inf'))
-    
+
     attn_probs = torch.softmax(attn_scores, dim=-1)
     output = torch.matmul(attn_probs, padded_v).squeeze(2)
-    
+
     return output
 
 
+IMPLS = {
+    "Naive PyTorch": naive_decode_attention,
+    "Fast PyTorch": decode_torch_optimized,
+    "Triton (old)": paged_attention_decode_triton_old,
+    "Triton (new)": paged_attention_decode_triton_new,
+}
+
+
+# =============================================================================
+# Test data, reference, timing
+# =============================================================================
 
 def setup_test_data(batch_size, seq_len, num_heads, num_kv_heads, head_dim, block_size, device='cuda'):
     """Setup test data for benchmarking"""
     # Query: (batch_size, num_heads, head_dim)
     q = torch.randn(batch_size, num_heads, head_dim, device=device, dtype=torch.float16)
-    
+
     # Calculate number of blocks needed
     max_num_blocks = (seq_len + block_size - 1) // block_size
     total_blocks = batch_size * max_num_blocks
-    
+
     # KV Cache: (total_blocks, block_size, num_kv_heads, head_dim)
     k_cache = torch.randn(total_blocks, block_size, num_kv_heads, head_dim, device=device, dtype=torch.float16)
     v_cache = torch.randn(total_blocks, block_size, num_kv_heads, head_dim, device=device, dtype=torch.float16)
-    
-    # Block tables: (batch_size, max_num_blocks)
-    block_tables = torch.arange(total_blocks, device=device, dtype=torch.int32).reshape(batch_size, max_num_blocks)
-    
+
+    # Block tables: (batch_size, max_num_blocks).
+    # Shuffled, not arange: a real BlockManager hands out whatever blocks are free,
+    # so logical order never matches physical order. An identity mapping would let
+    # a kernel that ignores the block table still produce the right answer.
+    perm = torch.randperm(total_blocks, device=device, dtype=torch.int32)
+    block_tables = perm.reshape(batch_size, max_num_blocks)
+
     # Context lengths: (batch_size,)
     context_lens = torch.full((batch_size,), seq_len, device=device, dtype=torch.int32)
-    
+
     # Scale
     scale = 1.0 / (head_dim ** 0.5)
-    
+
     return q, k_cache, v_cache, block_tables, context_lens, scale
 
 
-def benchmark(batch_size, seq_len, num_heads=32, num_kv_heads=8, 
-                                  head_dim=128, block_size=16, num_iterations=100):
-    """Compare all three implementations"""
-    
-    print(f"\n{'='*70}")
+def reference_output(q, k_cache, v_cache, block_tables, context_lens,
+                     scale, num_heads, num_kv_heads, head_dim, block_size):
+    """Float32 attention over the logical sequence gathered from the paged cache."""
+    batch_size = q.shape[0]
+    out = torch.empty(batch_size, num_heads, head_dim, device=q.device, dtype=torch.float32)
+    for b in range(batch_size):
+        ctx = int(context_lens[b].item())
+        idx = torch.arange(ctx, device=q.device)
+        phys = block_tables[b][idx // block_size].long()
+        off = idx % block_size
+        K = k_cache[phys, off].float()   # (ctx, num_kv_heads, head_dim)
+        V = v_cache[phys, off].float()
+        for h in range(num_heads):
+            kvh = h // (num_heads // num_kv_heads)
+            s = (q[b, h].float() @ K[:, kvh].T) * scale
+            out[b, h] = torch.softmax(s, dim=-1) @ V[:, kvh]
+    return out
+
+
+def time_ms(fn, warmup, iters):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters
+
+
+def benchmark(batch_size, seq_len, num_heads=16, num_kv_heads=8,
+              head_dim=128, block_size=256, num_iterations=100, warmup=10, tol=2e-2):
+    """Check every implementation against a float32 reference, then time it."""
+
+    print(f"\n{'='*74}")
     print(f"batch_size={batch_size}, seq_len={seq_len}, num_heads={num_heads}")
     print(f"num_kv_heads={num_kv_heads}, head_dim={head_dim}, block_size={block_size}")
-    print(f"{'='*70}")
-    
-    # Setup data
+    print(f"{'='*74}")
+
     q, k_cache, v_cache, block_tables, context_lens, scale = setup_test_data(
         batch_size, seq_len, num_heads, num_kv_heads, head_dim, block_size
     )
-    
+    ref = reference_output(q, k_cache, v_cache, block_tables, context_lens,
+                           scale, num_heads, num_kv_heads, head_dim, block_size)
+
+    header = f"{'implementation':<16} {'max_err':>10} {'correct':>8} {'ms':>9} {'speedup':>8}"
+    print(header)
+    print("-" * len(header))
+
     results = {}
-    
-    # 1. Naive implementation (your original?)
-    print("\n1. Testing Naive PyTorch implementation...")
-    for _ in range(10):  # warmup
-        _ = naive_decode_attention(q, k_cache, v_cache, block_tables, context_lens,
-                                   scale, num_heads, num_kv_heads, head_dim, block_size)
-    
-    torch.cuda.synchronize()
-    start = time.perf_counter()
-    for _ in range(num_iterations):
-        out_naive = naive_decode_attention(q, k_cache, v_cache, block_tables, context_lens,
-                                           scale, num_heads, num_kv_heads, head_dim, block_size)
-    torch.cuda.synchronize()
-    naive_time = (time.perf_counter() - start) / num_iterations
-    results['Naive PyTorch'] = naive_time
-    print(f"   Time: {naive_time*1000:.3f}ms")
-    
-    # 2. Optimized PyTorch
-    print("\n2. Testing Optimized PyTorch implementation...")
-    for _ in range(10):  # warmup
-        _ = decode_torch_optimized(q, k_cache, v_cache, block_tables, context_lens,
-                                   scale, num_heads, num_kv_heads, head_dim, block_size)
-    
-    torch.cuda.synchronize()
-    start = time.perf_counter()
-    for _ in range(num_iterations):
-        out_pytorch = decode_torch_optimized(q, k_cache, v_cache, block_tables, context_lens,
-                                            scale, num_heads, num_kv_heads, head_dim, block_size)
-    torch.cuda.synchronize()
-    pytorch_time = (time.perf_counter() - start) / num_iterations
-    results['Optimized PyTorch'] = pytorch_time
-    print(f"   Time: {pytorch_time*1000:.3f}ms")
-    
-    # 3. Triton
-    print("\n3. Testing Triton implementation...")
-    for _ in range(10):  # warmup
-        _ = paged_attention_decode_triton(q, k_cache, v_cache, block_tables, context_lens,
-                                          scale, num_heads, num_kv_heads, head_dim, block_size)
-    
-    torch.cuda.synchronize()
-    start = time.perf_counter()
-    for _ in range(num_iterations):
-        out_triton = paged_attention_decode_triton(q, k_cache, v_cache, block_tables, context_lens,
-                                                   scale, num_heads, num_kv_heads, head_dim, block_size)
-    torch.cuda.synchronize()
-    triton_time = (time.perf_counter() - start) / num_iterations
-    results['Triton'] = triton_time
-    print(f"   Time: {triton_time*1000:.3f}ms")
-    
+    baseline_ms = None
+
+    for name, impl in IMPLS.items():
+        call = lambda impl=impl: impl(q, k_cache, v_cache, block_tables, context_lens,
+                                      scale, num_heads, num_kv_heads, head_dim, block_size)
+        try:
+            out = call()
+            err = (out.float() - ref).abs().max().item()
+        except RuntimeError as e:
+            # An out-of-bounds read poisons the CUDA context: every later launch in
+            # this process would fail too, so report and stop rather than emit noise.
+            print(f"{name:<16} {'CRASH':>10} {'no':>8}")
+            print(f"\n{name} raised: {type(e).__name__}: {str(e).splitlines()[0]}")
+            print("The CUDA context cannot be recovered in-process; "
+                  "rerun with a smaller config to measure the remaining cases.")
+            raise SystemExit(1)
+
+        correct = err < tol
+        ms = time_ms(call, warmup=warmup, iters=num_iterations)
+        if baseline_ms is None:
+            baseline_ms = ms
+        results[name] = ms
+        print(f"{name:<16} {err:>10.5f} {'yes' if correct else 'NO':>8} "
+              f"{ms:>9.3f} {baseline_ms / ms:>7.2f}x")
+
+    print(f"\nmax_err is vs a float32 reference; speedup is vs {next(iter(IMPLS))}.")
+    print("A 'NO' in the correct column means the timing is meaningless -- that")
+    print("implementation is not computing attention over the right tokens.")
     return results
 
 
+def main():
+    parser = argparse.ArgumentParser(description="Paged attention decode benchmark.")
+    parser.add_argument("--batch-sizes", type=int, nargs="+", default=[1, 8, 32])
+    parser.add_argument("--seq-lens", type=int, nargs="+", default=[128, 512, 2048])
+    parser.add_argument("--num-heads", type=int, default=16)
+    parser.add_argument("--num-kv-heads", type=int, default=8)
+    parser.add_argument("--head-dim", type=int, default=128)
+    # 256 is what main.py / models/llama.py actually configure. Note that the
+    # Attention class itself still defaults to 16.
+    parser.add_argument("--block-size", type=int, default=256)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--warmup", type=int, default=10)
+    args = parser.parse_args()
+
+    print("\n" + "=" * 74)
+    print("PAGED ATTENTION DECODE BENCHMARK")
+    print("Comparing: " + " | ".join(IMPLS))
+    print("=" * 74)
+
+    for batch_size in args.batch_sizes:
+        for seq_len in args.seq_lens:
+            benchmark(batch_size=batch_size, seq_len=seq_len,
+                      num_heads=args.num_heads, num_kv_heads=args.num_kv_heads,
+                      head_dim=args.head_dim, block_size=args.block_size,
+                      num_iterations=args.iters, warmup=args.warmup)
+
+
 if __name__ == "__main__":
-    print("\n" + "="*70)
-    print("COMPREHENSIVE PAGED ATTENTION DECODE BENCHMARK")
-    print("Comparing: Naive PyTorch | Optimized PyTorch | Triton")
-    print("="*70)
-    
-    benchmark(batch_size=2, seq_len=60, num_iterations=100)
-    benchmark(batch_size=1, seq_len=512, num_iterations=100)
-    benchmark(batch_size=16, seq_len=256, num_iterations=50)
-    benchmark(batch_size=4, seq_len=2048, num_iterations=20)
+    main()

--- a/src/myvllm/layers/attention.py
+++ b/src/myvllm/layers/attention.py
@@ -337,34 +337,19 @@ def paged_attention_decode_kernel(
             # Compute attention scores for this chunk
             qk = tl.zeros([BLOCK_N], dtype=tl.float32) - 1e10
             
-            # Load K for each valid position and compute scores
-            for i in range(BLOCK_N):
-                token_idx = token_start + i
-                if token_idx < context_len:
-                    block_num = token_idx // block_size
-                    block_offset = token_idx % block_size
-                    
-                    if block_num < max_num_blocks:
-                        # Look up physical block
-                        block_table_offset = batch_idx * max_num_blocks + block_num
-                        physical_block_idx = tl.load(block_tables_ptr + block_table_offset)
-                        
-                        if physical_block_idx != -1:
-                            # Load K
-                            k_offset = (physical_block_idx * block_size * num_kv_heads * head_dim +
-                                       block_offset * num_kv_heads * head_dim +
-                                       kv_head_idx * head_dim + offs_d)
-                            k_vec = tl.load(k_cache_ptr + k_offset)
-                            
-                            # Compute score for this token
-                            score = tl.sum(q * k_vec) * scale
-                            
-                            # Update qk array at position i using tl.where
-                            mask_i = tl.arange(0, BLOCK_N) == i
-                            qk = tl.where(mask_i, score, qk)
-            
-            # Apply mask to invalid positions
-            qk = tl.where(mask_n, qk, -1e10)
+            # Load K for each position and compute scores
+            block_idx = (token_start) // block_size
+            physical_block_idx = tl.load(block_tables_ptr + batch_idx * max_num_blocks + block_idx)
+            if physical_block_idx!=-1 :
+                # 物理块地址中读出BLOCK_M token的kv
+                k_offset = (physical_block_idx * block_size * num_kv_heads * head_dim # 块开始位置
+                            + offs_n[None,:] * num_kv_heads * head_dim
+                            + kv_head_idx * head_dim 
+                            + offs_d[:,None])
+                k = tl.load(k_cache_ptr + k_offset, mask=mask_n[None,:],other=0.0)
+                k = tl.cast(k,tl.float32)
+                score = tl.sum(q[:,None] * k, axis=0) * scale
+                qk = tl.where(mask_n, score, -1e10)
             
             # Online softmax
             m_ij = tl.max(qk)
@@ -376,31 +361,20 @@ def paged_attention_decode_kernel(
             acc = acc * alpha
             l_i = l_i * alpha
             
-            # Load V and accumulate
-            for i in range(BLOCK_N):
-                token_idx = token_start + i
-                if token_idx < context_len:
-                    block_num = token_idx // block_size
-                    block_offset = token_idx % block_size
-                    
-                    if block_num < max_num_blocks:
-                        # Look up physical block
-                        block_table_offset = batch_idx * max_num_blocks + block_num
-                        physical_block_idx = tl.load(block_tables_ptr + block_table_offset)
-                        
-                        if physical_block_idx != -1:
-                            # Load V
-                            v_offset = (physical_block_idx * block_size * num_kv_heads * head_dim +
-                                       block_offset * num_kv_heads * head_dim +
-                                       kv_head_idx * head_dim + offs_d)
-                            v_vec = tl.load(v_cache_ptr + v_offset)
-                            
-                            # Extract weight for this token from p
-                            mask_i = tl.arange(0, BLOCK_N) == i
-                            weight = tl.sum(tl.where(mask_i, p, 0.0))
-                            
-                            acc = acc + weight * v_vec
-                            l_i = l_i + weight
+            # Load V for each position and compute result
+            block_idx = (token_start) // block_size
+            physical_block_idx = tl.load(block_tables_ptr + batch_idx * max_num_blocks + block_idx)
+            if physical_block_idx!=-1 :
+                # 物理块地址中读出BLOCK_M token的kv
+                v_offset = (physical_block_idx * block_size * num_kv_heads * head_dim # 块开始位置
+                            + offs_n[None,:] * num_kv_heads * head_dim
+                            + kv_head_idx * head_dim 
+                            + offs_d[:,None])
+                v = tl.load(v_cache_ptr + v_offset, mask=mask_n[None,:],other=0.0)
+                v = tl.cast(v,tl.float32)
+                weight = tl.where(mask_n, p, 0.0)
+                acc = acc + tl.sum(weight[None,:] * v,axis=1)
+                l_i = l_i + tl.sum(weight)
             
             m_i = m_i_new
     

--- a/src/myvllm/layers/attention.py
+++ b/src/myvllm/layers/attention.py
@@ -299,6 +299,12 @@ def paged_attention_decode_kernel(
     """
     Optimized paged attention kernel for decode phase.
     Processes KV cache in chunks.
+
+    The block table is gathered per token rather than per chunk, so a chunk may
+    straddle any number of blocks and no relation between BLOCK_N and block_size
+    is assumed. Each lane resolves its own token independently:
+
+        token t  ->  block_tables[batch, t // block_size], slot t % block_size
     """
     batch_idx = tl.program_id(0)
     head_idx = tl.program_id(1)
@@ -331,51 +337,53 @@ def paged_attention_decode_kernel(
         if token_start < context_len:
             # Determine which tokens in this chunk are valid
             offs_n = token_start + tl.arange(0, BLOCK_N)
-            mask_n = offs_n < context_len
-            
-          
+            logical_block = offs_n // block_size
+            # physical_block * block_size already moves the base pointer to the
+            # start of the block, so what is added is the offset *within* the
+            # block, not the global token index.
+            offs_in_block = offs_n % block_size
+
+            in_range = (offs_n < context_len) & (logical_block < max_num_blocks)
+
+            # One block-table entry per token: a chunk is free to span several
+            # blocks, and those blocks need not be adjacent in the cache.
+            physical_block = tl.load(
+                block_tables_ptr + batch_idx * max_num_blocks + logical_block,
+                mask=in_range, other=-1)
+            valid = in_range & (physical_block != -1)
+            # Masked-out lanes still take part in the address arithmetic, so give
+            # them block 0 to keep every computed offset inside the cache.
+            physical_block = tl.where(valid, physical_block, 0).to(tl.int64)
+
+            # Cache: (num_blocks, block_size, num_kv_heads, head_dim)
+            kv_offset = (physical_block[None, :] * (block_size * num_kv_heads * head_dim)
+                         + offs_in_block[None, :] * (num_kv_heads * head_dim)
+                         + kv_head_idx * head_dim
+                         + offs_d[:, None])
+
             # Compute attention scores for this chunk
-            qk = tl.zeros([BLOCK_N], dtype=tl.float32) - 1e10
-            
-            # Load K for each position and compute scores
-            block_idx = (token_start) // block_size
-            physical_block_idx = tl.load(block_tables_ptr + batch_idx * max_num_blocks + block_idx)
-            if physical_block_idx!=-1 :
-                # 物理块地址中读出BLOCK_M token的kv
-                k_offset = (physical_block_idx * block_size * num_kv_heads * head_dim # 块开始位置
-                            + offs_n[None,:] * num_kv_heads * head_dim
-                            + kv_head_idx * head_dim 
-                            + offs_d[:,None])
-                k = tl.load(k_cache_ptr + k_offset, mask=mask_n[None,:],other=0.0)
-                k = tl.cast(k,tl.float32)
-                score = tl.sum(q[:,None] * k, axis=0) * scale
-                qk = tl.where(mask_n, score, -1e10)
-            
+            k = tl.load(k_cache_ptr + kv_offset, mask=valid[None, :], other=0.0)
+            k = tl.cast(k, tl.float32)
+            score = tl.sum(q[:, None] * k, axis=0) * scale
+            qk = tl.where(valid, score, -1e10)
+
             # Online softmax
             m_ij = tl.max(qk)
             m_i_new = tl.maximum(m_i, m_ij)
             alpha = tl.exp(m_i - m_i_new)
             p = tl.exp(qk - m_i_new)
-            
+
             # Rescale accumulator
             acc = acc * alpha
             l_i = l_i * alpha
-            
-            # Load V for each position and compute result
-            block_idx = (token_start) // block_size
-            physical_block_idx = tl.load(block_tables_ptr + batch_idx * max_num_blocks + block_idx)
-            if physical_block_idx!=-1 :
-                # 物理块地址中读出BLOCK_M token的kv
-                v_offset = (physical_block_idx * block_size * num_kv_heads * head_dim # 块开始位置
-                            + offs_n[None,:] * num_kv_heads * head_dim
-                            + kv_head_idx * head_dim 
-                            + offs_d[:,None])
-                v = tl.load(v_cache_ptr + v_offset, mask=mask_n[None,:],other=0.0)
-                v = tl.cast(v,tl.float32)
-                weight = tl.where(mask_n, p, 0.0)
-                acc = acc + tl.sum(weight[None,:] * v,axis=1)
-                l_i = l_i + tl.sum(weight)
-            
+
+            # Accumulate weighted values
+            v = tl.load(v_cache_ptr + kv_offset, mask=valid[None, :], other=0.0)
+            v = tl.cast(v, tl.float32)
+            weight = tl.where(valid, p, 0.0)
+            acc = acc + tl.sum(weight[None, :] * v, axis=1)
+            l_i = l_i + tl.sum(weight)
+
             m_i = m_i_new
     
     # Normalize


### PR DESCRIPTION
## Performance Optimization: Token-Block Parallelism for PagedAttention

This PR optimizes the PagedAttention decode kernel in `src/layers/attention` by refactoring the **BLOCKM** processing logic. I replaced the original linear, token-by-token sequential processing with a **token-block parallelization** approach, which significantly improves hardware utilization and instruction throughput during the decoding phase.

The performance gains were validated by integrating the kernel into `nanovllm` (adjust a redundant scale factor in `Attention.forward()`), as the current repository's `force_eager=False` path is unstable. Benchmarks show a **~2.5x reduction in average decode latency**, effectively addressing the performance bottlenecks in the existing implementation.


Update doc, update benchmark as well

Closes #64