### PR TITLE
fix bug #37 and #62 and #70 and #75

### DIFF
--- a/src/myvllm/engine/block_manager.py
+++ b/src/myvllm/engine/block_manager.py
@@ -92,6 +92,7 @@ class BlockManager:
                 # cache miss
                 block = self._allocate_block(self.free_block_ids[0])
                 block.update(h=h, token_ids=token_ids)
+                block.ref_count = 1
                 if h != -1:
                     self.hash_to_block_id[h] = block.block_id
             seq.block_table.append(block.block_id)

--- a/src/myvllm/engine/block_manager.py
+++ b/src/myvllm/engine/block_manager.py
@@ -17,8 +17,12 @@ class Block:
         self.token_ids = token_ids
 
     def reset(self):
-        self.hash = -1 
-        self.ref_count = 0
+        self.hash = -1
+        # reset() is only reached via BlockManager._allocate_block, which takes the
+        # block off the free list on behalf of exactly one sequence. Allocation is
+        # therefore the first reference: leaving this at 0 makes the matching
+        # deallocate() drive ref_count to -1, so the block is never freed.
+        self.ref_count = 1
         self.token_ids = []
 
 class BlockManager:
@@ -55,6 +59,15 @@ class BlockManager:
     def _deallocate_block(self, block_id: int) -> None:
         assert self.blocks[block_id].ref_count == 0, "Block is still in use"
         block = self.blocks[block_id]
+        # Clearing token_ids deliberately keeps the prefix cache scoped to blocks that
+        # are still referenced: a freed block can no longer match in allocate(), so a
+        # cache hit never spans a finished sequence. Reuse across sequences is not
+        # enabled yet because the prefill path cannot consume it -- the Triton kernel
+        # in layers/attention.py attends only over the K/V computed in that pass and
+        # ignores context.block_tables, and qwen3 derives RoPE positions from
+        # cu_seqlens_q, so both would be wrong by num_cached_tokens. Enabling reuse
+        # means a paged prefill kernel (cu_seqlens_q != cu_seqlens_k) plus a position
+        # offset; until then this line is what keeps the engine correct.
         block.token_ids = []
         self.used_block_ids.remove(block_id)
         self.free_block_ids.append(block_id)
@@ -83,6 +96,9 @@ class BlockManager:
                 seq.num_cached_tokens += self.block_size # which == len(token_ids)
                 # update block information, considering the edge case that the block is not allocated yet but with hash code
                 if block_id not in self.used_block_ids:
+                    # Unreachable while _deallocate_block clears token_ids: a freed
+                    # block has token_ids == [] and fails the match above. Kept for
+                    # when cross-sequence reuse is enabled.
                     block = self._allocate_block(block_id)
                 else:
                     # update block information
@@ -92,7 +108,6 @@ class BlockManager:
                 # cache miss
                 block = self._allocate_block(self.free_block_ids[0])
                 block.update(h=h, token_ids=token_ids)
-                block.ref_count = 1
                 if h != -1:
                     self.hash_to_block_id[h] = block.block_id
             seq.block_table.append(block.block_id)
@@ -111,7 +126,12 @@ class BlockManager:
     # this is to check whether we can append tokens to this sequence
     # when that token would require allocating a new block.
     def can_append(self, seq: Sequence) -> bool:
-        if seq.num_tokens % self.block_size == 0:
+        # Called after the new token is already counted in seq.num_tokens, so the
+        # condition must match append()'s allocation branch: a fresh block is only
+        # needed when that token is the first of a new block (num_tokens % size == 1).
+        # At num_tokens % size == 0 the token still fits in the block the sequence
+        # already holds, and append() merely finalizes its hash.
+        if seq.num_tokens % self.block_size == 1:
             return len(self.free_block_ids) > 0
         return True
 

--- a/src/myvllm/engine/llm_engine.py
+++ b/src/myvllm/engine/llm_engine.py
@@ -65,10 +65,11 @@ class LLMEngine:
     # return scheduled sequences and whether it is for prefilling
     # call model_runner.run() to run the model
     # call postprocessor to process the outputs and update sequences and update block manager
-    def step(self) -> tuple[list[int], bool]:
+    def step(self) -> tuple[list[tuple[int, list[int]]], int, bool]:
         scheduled_sequences, is_prefill = self.scheduler.schedule()
+        num_processed_tokens = 0
         if not scheduled_sequences:
-            return [], is_prefill
+            return [], num_processed_tokens, is_prefill
         # run the model
         outputs = self.model_runner.call("run", scheduled_sequences, is_prefill)
         # Move outputs to CPU and convert them to a list

--- a/src/myvllm/engine/scheduler.py
+++ b/src/myvllm/engine/scheduler.py
@@ -19,12 +19,25 @@ class Scheduler:
         return len(self.waiting) == 0 and len(self.running) == 0
     
     def add_sequence(self, sequence: Sequence):
+        # Reject up front what the block manager could never satisfy, otherwise the
+        # sequence sits in `waiting` forever and only surfaces as a stalled engine.
+        capacity = len(self.block_manager.blocks)
+        if sequence.num_blocks > capacity:
+            raise ValueError(
+                f"Sequence {sequence.seq_id} needs {sequence.num_blocks} blocks "
+                f"({len(sequence)} tokens at block_size={self.block_manager.block_size}) "
+                f"but the KV cache only holds {capacity}. "
+                f"Raise max_cached_blocks or block_size, or shorten the prompt."
+            )
         self.waiting.append(sequence)
 
 
     def schedule(self) -> tuple[list[Sequence], bool]:
         scheduled_sequences = []
         current_scheduled_tokens = 0
+        # An empty schedule is only legitimate when this call freed blocks by
+        # preempting, so the next call can make progress. See the guard below.
+        preempted = False
         # try schedule for prefilling from waiting queue if not exceeding limits
         while self.waiting and len(scheduled_sequences) < self.max_num_sequences:
             seq = self.waiting[0]
@@ -45,6 +58,7 @@ class Scheduler:
             seq = self.running.popleft()
             # use can_append to check whether we can append one more token
             if not self.block_manager.can_append(seq):
+                preempted = True
                 if self.running:
                     self.running.appendleft(seq)
                     self.preempt(self.running.pop())
@@ -63,6 +77,18 @@ class Scheduler:
         # re-add to running queue in the same order
         if scheduled_sequences:
             self.running.extendleft(reversed(scheduled_sequences))
+        elif not preempted and (self.waiting or self.running):
+            # Nothing was scheduled and nothing was preempted, so no engine state
+            # changed: every later schedule() would take the same decisions and
+            # LLMEngine.generate() would spin forever. Fail loudly instead.
+            raise RuntimeError(
+                "Scheduler made no progress: "
+                f"{len(self.waiting)} waiting and {len(self.running)} running sequences, "
+                f"{len(self.block_manager.free_block_ids)} of "
+                f"{len(self.block_manager.blocks)} blocks free. "
+                "This means either a sequence that cannot fit in the KV cache, or "
+                "blocks leaked because their ref_count never returned to 0."
+            )
 
         return scheduled_sequences, False
 


### PR DESCRIPTION
# Surface Cause
Both issues #37 and #62 mentioned this issue. The surface cause of the bug is that the `step` method in the [llm_engine.py](https://github.com/Wenyueh/MinivLLM/blob/main/src/myvllm/engine/llm_engine.py#L68-L83) file did not exit the outer `while` loop after processing all the sequences. The `step` method returns two values: `return [], is_prefill`. However, the external function expects three values: `outputs, num_processed_tokens, is_prefill = self.step()`. However, this is not the root cause.
```python
    def step(self) -> tuple[list[int], bool]:
        scheduled_sequences, is_prefill = self.scheduler.schedule()
        if not scheduled_sequences:
            return [], is_prefill  # here!
        # run the model
        outputs = self.model_runner.call("run", scheduled_sequences, is_prefill)
        # Move outputs to CPU and convert them to a list
        if outputs is not None:
            outputs = outputs.cpu().tolist()
        # postprocess the outputs
        self.scheduler.postprocess(scheduled_sequences, outputs)


        outputs = [(seq.seq_id, seq.completion_token_ids) for seq in scheduled_sequences if seq.is_finished]
        num_processed_tokens = sum(len(seq) for seq in scheduled_sequences) if is_prefill else len(scheduled_sequences)


        return outputs, num_processed_tokens, is_prefill
```

# In-depth Analysis
Upon deeper investigation, with a sequence count of 90 (3 prompts * 30), it was found that the number of items in the waiting queue did not decrease when it reached the maximum allocable space (the 3070ti 8G's block allocation limit is 65). After investigation, it was discovered that the issue was due to a logical error in the `ref_count` counter, which prevented the block from being correctly released. This issue can be fixed by adding code in the [block_manager.py](https://github.com/Wenyueh/MinivLLM/blob/main/src/myvllm/engine/block_manager.py#L94) file.
```python
            else:
                # cache miss
                block = self._allocate_block(self.free_block_ids[0])
                block.update(h=h, token_ids=token_ids)
                block.ref_count = 1   # add this!
                if h != -1:
                    self.hash_to_block_id[h] = block.block_id
            seq.block_table.append(block.block_id)
````

# Another Scenario
After setting `block_size=8`, the program does not throw an error. The root cause is that the prompts themselves are too small. The original default setting of `block_size=256` meant that a single sequence could not fully use up the block. Moreover, due to an initialization issue with the `ref_count` at the lower level, only 65 running sequences will be executed (the number of running sequences corresponds to the known block count). Once the running sequence queue finishes, the waiting sequence queue will not continue running, which leads to the block release issue caused by the `ref_count`.



fix #70  #75 