### PR TITLE
Fix potential issues when the 'enforce_ceager' mode is set to 'False' #72

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ config = {
     'block_size': 256,
     'world_size': 1,
     'model_name_or_path': 'Qwen/Qwen3-0.6B',
-    'enforce_eager': True,
+    'enforce_eager': False,
     'vocab_size': 151936,  # Fixed: was 151643, HF model uses 151936
     'hidden_size': 1024,
     'num_heads': 16,

--- a/src/myvllm/engine/model_runner.py
+++ b/src/myvllm/engine/model_runner.py
@@ -285,12 +285,14 @@ class ModelRunner:
             seqlens_k.append(len(token_ids))
             cu_seqlens_q.append(cu_seqlens_q[-1] + seqlens_q[-1])
             cu_seqlens_k.append(cu_seqlens_k[-1] + seqlens_k[-1])
+            # by token generate slot_mapping
             if seq.block_table:
-                for i, block_id in enumerate(seq.block_table[seq.num_cached_blocks:]):
-                    if seq.num_cached_blocks + i != seq.num_blocks - 1:
-                        slot_mappings.extend(list(range(block_id * self.block_size, (block_id+1) * self.block_size)))
-                    else:
-                        slot_mappings.extend(list(range(block_id * self.block_size, block_id * self.block_size + seq.last_block_num_tokens)))
+                for pos in range(num_cached_tokens, len(token_ids)):
+                    block_idx = pos // self.block_size
+                    block_offset = pos % self.block_size
+                    block_id = seq.block_table[block_idx]
+                    slot_mappings.append(block_id * self.block_size + block_offset)
+                    
         if cu_seqlens_q[-1] < cu_seqlens_k[-1]:
             # pad block_tables
             all_block_tables = [seq.block_table for seq in seqs]
@@ -404,7 +406,7 @@ class ModelRunner:
     # (later use graph.replay() to run the captured graph)
     @torch.inference_mode()
     def capture_cudagraph(self) -> None:
-        max_bs = self.config['max_num_seqs']
+        max_bs = self.config['max_num_sequences']
         max_len = self.config['max_model_length']
         max_num_blocks = math.ceil(max_len / self.block_size)
         # for decoding, input is always of shape (batch_size, 1)
@@ -417,7 +419,7 @@ class ModelRunner:
         # where to read KV values in the cache
         block_tables = torch.zeros(max_bs, max_num_blocks, dtype=torch.int32, device=f'cuda:{self.rank}')
         # output logits
-        outputs = torch.zeros(max_bs, self.config['vocab_size'], device=f'cuda:{self.rank}')
+        outputs = torch.zeros(max_bs, self.config['hidden_size'], device=f'cuda:{self.rank}')
 
         # graphs to be captured for different batch sizes
         batch_sizes = [1, 2, 4, 8] + list(range(16, max_bs + 1, 16))
@@ -440,8 +442,9 @@ class ModelRunner:
 
             with torch.cuda.graph(graph, graph_pool):
                 outputs[:batch_size] = self.model(input_ids[:batch_size])
-                if graph_pool is None:
-                    graph_pool = graph.pool()
+
+            if graph_pool is None:
+                graph_pool = graph.pool()
             # store the captured graph
             self.graphs[batch_size] = graph
 


### PR DESCRIPTION
The main issues include the following:

1. `slot_mapping`  was originally mapped at block granularity, while `input_ids` operate at token granularity. As a result, when a block is not fully occupied, `slot_mapping ` ignores the unfilled block and proceeds starting from the next new block.
```python
  # by block
  # for i, block_id in enumerate(seq.block_table[seq.num_cached_blocks:]):
  #     if seq.num_cached_blocks + i != seq.num_blocks - 1:
  #         slot_mappings.extend(list(range(block_id * self.block_size, (block_id+1) * self.block_size)))
  #     else:
  #         slot_mappings.extend(list(range(block_id * self.block_size, block_id * self.block_size + seq.last_block_num_tokens)))

  # by token
  for pos in range(num_cached_tokens, len(token_ids)):
      block_idx = pos // self.block_size
      block_offset = pos % self.block_size
      block_id = seq.block_table[block_idx]
      slot_mappings.append(block_id * self.block_size + block_offset)
```
2. The variable shape setting in the CUDA graph has an issue: the parameter name `max_num_seqs` is inconsistent with the setting in the config; the model's final `output` is the `output` without Softmax, not the logits.
```python
   # max_bs = self.config['max_num_seqs']
  max_bs = self.config['max_num_sequences']

  # outputs = torch.zeros(max_bs, self.config['vocab_size'], device=f'cuda:{self.rank}')
  outputs = torch.zeros(max_bs, self.config['hidden_size'], device=f'cuda:{self.rank}')
```

4. CUDA graph should be captured after the graph generation is completed.
```python
    with torch.cuda.graph(graph, graph_pool):
        outputs[:batch_size] = self.model(input_ids[:batch_size])
        # The CUDA image capture process is not yet completed
        # if graph_pool is None:
        #     graph_pool = graph.pool()

    #After capturing the CUDA graph, save it
    if graph_pool is None:
        graph_pool = graph.pool()
```