### PR TITLE
fix: correct last block token count on full block boundary Wenyueh/MinivLLM#76

### DIFF
--- a/src/myvllm/engine/sequence.py
+++ b/src/myvllm/engine/sequence.py
@@ -69,8 +69,7 @@ class Sequence:
 
     @property
     def last_block_num_tokens(self):
-        full_blocks = int(math.floor(self.num_tokens / self.block_size))
-        return len(self.token_ids[full_blocks * self.block_size : ])
+        return self.num_tokens - max(self.num_blocks - 1, 0) * self.block_size
 
     def block(self, i):
         assert 0 <= i < self.num_blocks, f"Block index {i} out of range [0, {self.num_blocks})"


### PR DESCRIPTION
This fixes `last_block_num_tokens` on full-block boundaries.

Previously, when the last block was full, `last_block_num_tokens` could behave inconsistently with the way it is used in decode slot calculation.

This change updates the formula so that the last block returns its actual token count on full-block boundaries.
