### PR TITLE
Clean up README typo/comments and remove dead debug code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This showcases how the custom vLLM implementation handles batched text generatio
 uv run python benchmark_prefilling.py
 ```
 
-This is the pefilling phase comparison
+This is the prefilling phase comparison
 
 Compares three attention implementations during the **prefilling phase** (processing input prompts):
 
@@ -86,8 +86,8 @@ myvllm/
 │   └── myvllm/           # Core vLLM implementation
 │       ├── models/       # Model implementations
 │       ├── engine/       # LLM engine logic, including sequence definition for input prompts, block management for KV cache management for GPU, scheduler for iteration-based scheduling of sequences, runner for actual implementation of running prefilling and decoding, and engine for generation API interface
-│       ├── layers/       # Components for model/
-│       ├── utils/        # context
+│       ├── layers/       # Model layer components (activation, attention, embeddings, etc.)
+│       ├── utils/        # Utility helpers and inference context management
 │       └── sampling_parameters.py
 ├── main.py              # Full inference demo
 ├── benchmark_prefilling.py   # Prefilling attention comparison

--- a/src/myvllm/models/qwen3.py
+++ b/src/myvllm/models/qwen3.py
@@ -110,10 +110,7 @@ class Qwen3Attention(nn.Module):
             q = self.q_norm(q)
             k = self.k_norm(k)
 
-        # DEBUG: Print positions to diagnose issue
-        import sys
-
-        q, k = self.rotary_emb(positions, q, k) 
+        q, k = self.rotary_emb(positions, q, k)
 
         o = self.attention(q, k, v)
         # o shape: (B*N, num_heads, head_dim)     - Per-GPU, different heads per GPU


### PR DESCRIPTION
## Summary

Small cleanup PR — documentation fixes plus removal of leftover debug code. No behavioral changes.

### Changes
1. **README**: fix typo `pefilling` → `prefilling` (the heading for the `benchmark_prefilling.py` section; the line just below already says "prefilling phase").
2. **README**: complete two truncated entries in the Project Structure block that were cut off mid-sentence (`# Components for model/`, `# context`), describing what actually lives in `layers/` and `utils/`.
3. **`src/myvllm/models/qwen3.py`**: remove a leftover `# DEBUG` comment and an unused `import sys` inside `Qwen3Attention.forward` (also drops a trailing whitespace on the following line).

All changes are verifiable by reading; no runtime/GPU needed.