### PR TITLE
Fix sequence block handling at exact boundaries

### DIFF
--- a/src/myvllm/engine/sequence.py
+++ b/src/myvllm/engine/sequence.py
@@ -69,17 +69,15 @@ class Sequence:
 
     @property
     def last_block_num_tokens(self):
-        full_blocks = int(math.floor(self.num_tokens / self.block_size))
-        return len(self.token_ids[full_blocks * self.block_size : ])
+        if self.num_tokens == 0:
+            return 0
+        return self.num_tokens - (self.num_blocks - 1) * self.block_size
 
     def block(self, i):
         assert 0 <= i < self.num_blocks, f"Block index {i} out of range [0, {self.num_blocks})"
-        if i == self.num_blocks - 1:
-            return self.token_ids[-self.last_block_num_tokens:]
-        else:
-            start_idx = i * self.block_size
-            end_idx = start_idx + self.block_size
-            return self.token_ids[start_idx : end_idx]
+        start_idx = i * self.block_size
+        end_idx = start_idx + self.block_size
+        return self.token_ids[start_idx:end_idx]
 
     def append_token(self, token_id):
         self.token_ids.append(token_id)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from myvllm.engine.sequence import Sequence
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "expected"),
+    [
+        (0, 0),
+        (1, 1),
+        (3, 3),
+        (4, 4),
+        (5, 1),
+        (8, 4),
+    ],
+)
+def test_last_block_num_tokens(num_tokens, expected):
+    seq = Sequence(list(range(num_tokens)), block_size=4)
+
+    assert seq.last_block_num_tokens == expected
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "expected_blocks"),
+    [
+        (3, [[0, 1, 2]]),
+        (4, [[0, 1, 2, 3]]),
+        (5, [[0, 1, 2, 3], [4]]),
+        (8, [[0, 1, 2, 3], [4, 5, 6, 7]]),
+    ],
+)
+def test_block_returns_only_tokens_in_requested_block(num_tokens, expected_blocks):
+    seq = Sequence(list(range(num_tokens)), block_size=4)
+
+    assert [seq.block(i) for i in range(seq.num_blocks)] == expected_blocks


### PR DESCRIPTION
## Description

When a sequence length is an exact multiple of `block_size`, `last_block_num_tokens` incorrectly returns `0`. This causes decode slot mapping to address the previous slot and can make the last logical block expand to the entire token sequence.

Fixes #76.

## Detailed

The original implementation computes the final block length from the suffix after all complete blocks:

```python
full_blocks = int(math.floor(self.num_tokens / self.block_size))
return len(self.token_ids[full_blocks * self.block_size:])
```

For 8 tokens with `block_size = 4`, the slice is `token_ids[8:]`, so its length is `0` even though the last block contains 4 tokens.

The original last-block access then evaluates:

```python
self.token_ids[-self.last_block_num_tokens:]
```

At an exact boundary this becomes `self.token_ids[-0:]`. Since `-0 == 0` in Python, it returns the entire sequence instead of only the final block. Besides the decode slot offset, this can affect block token metadata and prefix-cache hashing.

## Solutions

- Compute the occupied length of the final block as `num_tokens - (num_blocks - 1) * block_size`, while preserving `0` for an empty sequence.
- Use the same forward slice, `token_ids[i * block_size:(i + 1) * block_size]`, for every logical block.
- Add regression tests for empty sequences, partial blocks, exact one-block boundaries, partial second blocks, and exact multi-block boundaries.
- Validate the change with `10 passed` focused sequence tests and Python bytecode compilation.
