### PR TITLE
Fix block ref count on allocation

### DIFF
--- a/src/myvllm/engine/block_manager.py
+++ b/src/myvllm/engine/block_manager.py
@@ -48,6 +48,7 @@ class BlockManager:
         block = self.blocks[block_id]
         assert block.ref_count == 0, "Block is already allocated"
         block.reset()
+        block.ref_count = 1
         self.free_block_ids.remove(block_id)
         self.used_block_ids.add(block_id)
         return block

--- a/tests/test_block_manager.py
+++ b/tests/test_block_manager.py
@@ -1,0 +1,48 @@
+from myvllm.engine.block_manager import BlockManager
+from myvllm.engine.sequence import Sequence
+
+
+def test_allocate_sets_ref_count_and_deallocate_releases_block():
+    manager = BlockManager(num_blocks=2, block_size=4)
+    seq = Sequence([1, 2, 3], block_size=4)
+
+    manager.allocate(seq)
+
+    assert seq.block_table == [0]
+    assert manager.blocks[0].ref_count == 1
+    assert manager.used_block_ids == {0}
+    assert list(manager.free_block_ids) == [1]
+
+    manager.deallocate(seq)
+
+    assert seq.block_table == []
+    assert manager.blocks[0].ref_count == 0
+    assert manager.used_block_ids == set()
+    assert list(manager.free_block_ids) == [1, 0]
+
+
+def test_prefix_cache_hit_increments_and_decrements_ref_count():
+    manager = BlockManager(num_blocks=2, block_size=4)
+    seq1 = Sequence([1, 2, 3, 4], block_size=4)
+    seq2 = Sequence([1, 2, 3, 4], block_size=4)
+
+    manager.allocate(seq1)
+    manager.allocate(seq2)
+
+    assert seq1.block_table == [0]
+    assert seq2.block_table == [0]
+    assert manager.blocks[0].ref_count == 2
+    assert manager.used_block_ids == {0}
+    assert list(manager.free_block_ids) == [1]
+
+    manager.deallocate(seq1)
+
+    assert manager.blocks[0].ref_count == 1
+    assert manager.used_block_ids == {0}
+    assert list(manager.free_block_ids) == [1]
+
+    manager.deallocate(seq2)
+
+    assert manager.blocks[0].ref_count == 0
+    assert manager.used_block_ids == set()
+    assert list(manager.free_block_ids) == [1, 0]


### PR DESCRIPTION
## Description

`BlockManager._allocate_block()` moves a block from the free list to the used set, which means the block is immediately owned by one sequence. However, the current implementation resets the block metadata and leaves `ref_count` at `0` after allocation.

This makes the reference count inconsistent with the block lifecycle. When the sequence is later deallocated, `deallocate()` decrements the count and may move it from `0` to `-1`, preventing the block from being returned to the free list.

## Detailed

The problematic code is in `src/myvllm/engine/block_manager.py`:

```python
def _allocate_block(self, block_id: int) -> Block:
    block = self.blocks[block_id]
    assert block.ref_count == 0, "Block is already allocated"
    block.reset()
    self.free_block_ids.remove(block_id)
    self.used_block_ids.add(block_id)
    return block
```

`block.reset()` sets `ref_count` to `0`, but after the block is removed from `free_block_ids` and added to `used_block_ids`, it should already have one active owner.

This conflicts with `deallocate()`:

```python
block.ref_count -= 1
if block.ref_count == 0:
    self._deallocate_block(block_id)
```

With the old allocation behavior, a freshly allocated block can go through `0 -> -1` instead of `1 -> 0`.

## Solutions

This PR sets `ref_count` to `1` inside `_allocate_block()` after resetting the block metadata:

```python
block.reset()
block.ref_count = 1
```

This keeps the block lifecycle consistent:

- new allocation: `0 -> 1`
- prefix cache sharing: `1 -> 2`
- first deallocation of shared block: `2 -> 1`
- final deallocation: `1 -> 0`, then the block is returned to the free list

This PR also adds `tests/test_block_manager.py` to cover:

- regular allocate/deallocate behavior
- prefix cache hit behavior where two sequences share the same cached block

Validation:

```bash
PYTHONPATH=src /home/txc_king/miniconda3/envs/dlenv/bin/python -m pytest tests/test_block_manager.py -q
PYTHONPATH=src /home/txc_king/miniconda3/envs/dlenv/bin/python -m compileall -q src/myvllm tests/test_block_manager.py
```

Test result: `2 passed`.
