### PR TITLE
Fix can_append block allocation check

### DIFF
--- a/src/myvllm/engine/block_manager.py
+++ b/src/myvllm/engine/block_manager.py
@@ -110,7 +110,7 @@ class BlockManager:
     # this is to check whether we can append tokens to this sequence
     # when that token would require allocating a new block.
     def can_append(self, seq: Sequence) -> bool:
-        if seq.num_tokens % self.block_size == 0:
+        if seq.num_blocks > len(seq.block_table):
             return len(self.free_block_ids) > 0
         return True
 

--- a/tests/test_block_manager.py
+++ b/tests/test_block_manager.py
@@ -1,0 +1,27 @@
+from myvllm.engine.block_manager import BlockManager
+from myvllm.engine.sequence import Sequence
+
+
+def test_can_append_allows_filling_existing_block_without_free_block():
+    manager = BlockManager(num_blocks=1, block_size=4)
+    seq = Sequence([1, 2, 3], block_size=4)
+    manager.allocate(seq)
+    seq.append_token(4)
+
+    assert list(manager.free_block_ids) == []
+    assert manager.can_append(seq)
+
+    manager.append(seq)
+
+    assert seq.block_table == [0]
+    assert list(manager.free_block_ids) == []
+
+
+def test_can_append_rejects_new_block_when_no_free_block_exists():
+    manager = BlockManager(num_blocks=1, block_size=4)
+    seq = Sequence([1, 2, 3, 4], block_size=4)
+    manager.allocate(seq)
+    seq.append_token(5)
+
+    assert list(manager.free_block_ids) == []
+    assert not manager.can_append(seq)


### PR DESCRIPTION
## Description

`BlockManager.can_append()` is used by the scheduler before decode to decide whether the current sequence can safely append its latest token into the KV cache block mapping.

The current check is based on `seq.num_tokens % block_size == 0`. This does not match the actual condition for needing a new block. A sequence does not need a new block merely because its current last block becomes full; it needs a new block only when the number of logical blocks required by the sequence exceeds the number of physical blocks already recorded in `seq.block_table`.

## Detailed

The problematic code is:

```python
def can_append(self, seq: Sequence) -> bool:
    if seq.num_tokens % self.block_size == 0:
        return len(self.free_block_ids) > 0
    return True
```

This creates two boundary problems for decode:

- When a sequence grows from length `3` to `4` with `block_size = 4`, the last token only fills the existing block. No new block is required, but the old check returns `False` if there are no free blocks, causing unnecessary preemption.
- When a sequence grows from length `4` to `5`, the last token starts a new logical block. A new physical block is required, but the old check returns `True`, allowing `append()` to later access `free_block_ids[0]` even when the free list is empty.

In other words, the old modulo check is off from the actual block-table requirement.

## Solutions

This PR changes `can_append()` to compare the logical block requirement with the physical block mapping already held by the sequence:

```python
def can_append(self, seq: Sequence) -> bool:
    if seq.num_blocks > len(seq.block_table):
        return len(self.free_block_ids) > 0
    return True
```

This directly expresses the scheduler admission condition:

- if the sequence already has enough mapped blocks, decode can continue without requiring a free block
- if the sequence needs one more block, decode can continue only when a free block exists

This PR also adds `tests/test_block_manager.py` with coverage for both boundary cases:

- filling an existing block without any free blocks available
- rejecting append when a new block is required but no free block exists

Validation:

```bash
PYTHONPATH=src /home/txc_king/miniconda3/envs/dlenv/bin/python -m pytest tests/test_block_manager.py -q
PYTHONPATH=src /home/txc_king/miniconda3/envs/dlenv/bin/python -m compileall -q src/myvllm tests/test_block_manager.py
```

Test result: `2 passed`.
