### PR TITLE
fix: preserve sequence state across workers

### DIFF
--- a/src/myvllm/engine/sequence.py
+++ b/src/myvllm/engine/sequence.py
@@ -69,6 +69,8 @@ class Sequence:
 
     @property
     def last_block_num_tokens(self):
+        if hasattr(self, "_last_block_num_tokens"):
+            return self._last_block_num_tokens
         full_blocks = int(math.floor(self.num_tokens / self.block_size))
         return len(self.token_ids[full_blocks * self.block_size : ])
 
@@ -87,29 +89,13 @@ class Sequence:
         self.num_tokens += 1 
 
     def __getstate__(self):
-        return (
-            self.num_tokens, 
-            self.num_prompt_tokens, 
-            self.num_cached_tokens, 
-            self.block_table,
-            self.token_ids if self.num_completion_tokens == 0 else self.last_token
-        )
+        state = self.__dict__.copy()
+        # Decode workers only need the latest token. Keep the existing compact
+        # shared-memory representation while preserving all other attributes.
+        if self.num_completion_tokens > 0:
+            state["_last_block_num_tokens"] = self.last_block_num_tokens
+            state["token_ids"] = [self.last_token]
+        return state
 
     def __setstate__(self, state):
-        (
-            self.num_tokens,
-            self.num_prompt_tokens,
-            self.num_cached_tokens,
-            self.block_table,
-            last_token_or_ids
-        ) = state
-        # Check if this is prefill (num_completion_tokens == 0) or decode phase
-        num_completion_tokens = self.num_tokens - self.num_prompt_tokens
-        if num_completion_tokens == 0:
-            # Prefill: last_token_or_ids is the full token_ids list
-            self.token_ids = last_token_or_ids
-        else:
-            # Decode: last_token_or_ids is just the last token
-            self.token_ids = [last_token_or_ids]
-        # Restore last_token attribute
-        self.last_token = self.token_ids[-1] if self.token_ids else None
+        self.__dict__.update(state)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -46,9 +46,9 @@ class TestBug2TokenLimitBreak:
     """
 
     def _run(self, scheduler: Scheduler):
-        seq_a = Sequence([1, 2, 3])
-        seq_b = Sequence([4, 5, 6])
-        seq_c = Sequence([7, 8, 9])
+        seq_a = Sequence([1, 2, 3], block_size=4)
+        seq_b = Sequence([4, 5, 6], block_size=4)
+        seq_c = Sequence([7, 8, 9], block_size=4)
         inject_running(scheduler, seq_a, seq_b, seq_c)
 
         scheduler.block_manager = MagicMock()
@@ -108,8 +108,8 @@ class TestBug1CanAppendFailure:
     """
 
     def _run(self, scheduler: Scheduler):
-        seq_a = Sequence([1, 2, 3])
-        seq_b = Sequence([4, 5, 6])
+        seq_a = Sequence([1, 2, 3], block_size=4)
+        seq_b = Sequence([4, 5, 6], block_size=4)
         inject_running(scheduler, seq_a, seq_b)
 
         mock_bm = MagicMock()
@@ -146,7 +146,7 @@ class TestBug1CanAppendFailure:
 class TestSchedulerHappyPath:
     def test_prefill_scheduled_first(self):
         scheduler = make_scheduler(max_num_batched_tokens=100, max_cached_blocks=50)
-        seq = Sequence([1, 2, 3, 4])
+        seq = Sequence([1, 2, 3, 4], block_size=4)
         scheduler.add_sequence(seq)
 
         scheduled, is_prefill = scheduler.schedule()
@@ -156,8 +156,8 @@ class TestSchedulerHappyPath:
 
     def test_all_running_seqs_scheduled_when_budget_allows(self):
         scheduler = make_scheduler(max_num_batched_tokens=10)
-        seq_a = Sequence([1])
-        seq_b = Sequence([2])
+        seq_a = Sequence([1], block_size=4)
+        seq_b = Sequence([2], block_size=4)
         inject_running(scheduler, seq_a, seq_b)
 
         scheduler.block_manager = MagicMock()
@@ -174,7 +174,7 @@ class TestSchedulerHappyPath:
     def test_preempt_only_seq_when_cant_append_and_running_empty(self):
         """Original else-branch: running=[seq], can_append=False → preempt seq → waiting."""
         scheduler = make_scheduler()
-        seq = Sequence([1, 2])
+        seq = Sequence([1, 2], block_size=4)
         inject_running(scheduler, seq)
 
         scheduler.block_manager = MagicMock()

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,0 +1,57 @@
+import pickle
+
+from myvllm.engine.sequence import Sequence, SequenceStatus
+from myvllm.sampling_parameters import SamplingParams
+
+
+def test_prefill_pickle_round_trip_preserves_sequence_state():
+    sampling_params = SamplingParams(
+        temperature=0.5,
+        max_tokens=32,
+        ignore_eos=True,
+        max_model_length=128,
+    )
+    seq = Sequence([1, 2, 3], block_size=4, sampling_params=sampling_params)
+    seq.status = SequenceStatus.RUNNING
+    seq.num_cached_tokens = 2
+    seq.block_table = [7]
+
+    restored = pickle.loads(pickle.dumps(seq))
+
+    assert restored.seq_id == seq.seq_id
+    assert restored.block_size == 4
+    assert restored.status is SequenceStatus.RUNNING
+    assert restored.token_ids == [1, 2, 3]
+    assert restored.last_token == 3
+    assert restored.num_tokens == 3
+    assert restored.num_prompt_tokens == 3
+    assert restored.num_cached_tokens == 2
+    assert restored.block_table == [7]
+    assert restored.temperature == 0.5
+    assert restored.max_tokens == 32
+    assert restored.ignore_eos is True
+    assert restored.max_model_length == 128
+
+
+def test_decode_pickle_round_trip_keeps_compact_tokens_and_required_state():
+    seq = Sequence(
+        [1, 2],
+        block_size=4,
+        sampling_params=SamplingParams(temperature=0.75),
+    )
+    seq.status = SequenceStatus.RUNNING
+    seq.block_table = [5]
+    seq.append_token(9)
+
+    restored = pickle.loads(pickle.dumps(seq))
+
+    assert restored.token_ids == [9]
+    assert restored.last_token == 9
+    assert restored.num_tokens == 3
+    assert restored.num_prompt_tokens == 2
+    assert restored.block_size == 4
+    assert restored.block_table == [5]
+    assert restored.status is SequenceStatus.RUNNING
+    assert restored.temperature == 0.75
+    assert restored.num_blocks == 1
+    assert restored.last_block_num_tokens == 3


### PR DESCRIPTION
## Summary

- preserve all `Sequence` attributes during pickle round trips
- retain the compact decode representation that sends only the latest token
- preserve the last-block token count required for decode slot mapping
- update scheduler tests for the required `block_size` argument
- add CPU-only serialization regression tests

## Problem

`Sequence.__getstate__` previously serialized only token counts, cached state, the block table, and token data. After unpickling, fields such as `block_size`, `seq_id`, status, and sampling parameters were missing.

Multi-GPU workers receive `Sequence` objects through pickle-backed shared memory, so accessing these fields could raise `AttributeError` or produce incorrect decode metadata.

## Tests

```text
UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q
10 passed
```