### PR TITLE
Fix block accounting and add cross-request prefix cache reuse

### DIFF
--- a/benchmark_tps.py
+++ b/benchmark_tps.py
@@ -24,6 +24,7 @@ config = {
     'world_size': 1,
     'model_name_or_path': 'Qwen/Qwen3-0.6B',
     'enforce_eager': True,
+    'dtype': 'bfloat16',
     'vocab_size': 151936,  # Fixed: was 151643, HF model uses 151936
     'hidden_size': 1024,
     'num_heads': 16,
@@ -38,7 +39,6 @@ config = {
     'scale': 1,
     'max_position': 32768, # should be >= max_model_length, max position index allowed in rotary embedding
     'ffn_bias': False,  # Fixed: HF Qwen3 doesn't use MLP bias
-    'max_num_batch_tokens': 4096,
     'max_model_length': 128,
     'gpu_memory_utilization': 0.9,
     'eos': 151645,  # Fixed: should match tokenizer.eos_token_id

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ config = {
     'world_size': 1,
     'model_name_or_path': 'Qwen/Qwen3-0.6B',
     'enforce_eager': True,
+    'dtype': 'bfloat16',
     'vocab_size': 151936,  # Fixed: was 151643, HF model uses 151936
     'hidden_size': 1024,
     'num_heads': 16,
@@ -34,7 +35,6 @@ config = {
     'scale': 1,
     'max_position': 32768, # should be >= max_model_length, max position index allowed in rotary embedding
     'ffn_bias': False,  # Fixed: HF Qwen3 doesn't use MLP bias
-    'max_num_batch_tokens': 4096,
     'max_model_length': 128,
     'gpu_memory_utilization': 0.9,
     'eos': 151645,  # Fixed: should match tokenizer.eos_token_id

--- a/main_llama32.py
+++ b/main_llama32.py
@@ -16,7 +16,7 @@ config = {
     'max_num_batched_tokens': 1024,
     'max_cached_blocks': 1024,
 
-    'max_num_batch_tokens': 4096,
+    'dtype': 'bfloat16',
     'max_model_length': 128,
     'gpu_memory_utilization': 0.9,
 

--- a/src/myvllm/engine/block_manager.py
+++ b/src/myvllm/engine/block_manager.py
@@ -153,9 +153,10 @@ class BlockManager:
         seq.num_cached_tokens = 0
 
     # this is to check whether we can append tokens to this sequence
-    # when that token would require allocating a new block.
+    # The token was already added to the sequence by postprocess(). A new
+    # block is needed when that token is the first token in a block.
     def can_append(self, seq: Sequence) -> bool:
-        if seq.num_tokens % self.block_size == 0:
+        if seq.num_tokens % self.block_size == 1:
             return len(self.free_block_ids) > 0
         return True
 

--- a/src/myvllm/engine/block_manager.py
+++ b/src/myvllm/engine/block_manager.py
@@ -27,8 +27,8 @@ class BlockManager:
         self.block_size: int = block_size
         # list of all blocks
         self.blocks: list[Block] = [Block(i) for i in range(num_blocks)]
-        # hash to block id: this is for prefix caching
-        self.hash_to_block_id: dict[int, int] = {}
+        # Multiple physical blocks can represent the same logical prefix.
+        self.hash_to_block_ids: dict[int, set[int]] = {}
         # free block ids
         self.free_block_ids: deque[int] = deque(range(num_blocks))
         # used block ids
@@ -43,6 +43,18 @@ class BlockManager:
         h.update(np.array(token_ids, dtype=np.int32).tobytes())
         return h.intdigest()
 
+    def _register_hash(self, hash_value: int, block_id: int) -> None:
+        if hash_value != -1:
+            self.hash_to_block_ids.setdefault(hash_value, set()).add(block_id)
+
+    def _unregister_hash(self, hash_value: int, block_id: int) -> None:
+        block_ids = self.hash_to_block_ids.get(hash_value)
+        if block_ids is None:
+            return
+        block_ids.discard(block_id)
+        if not block_ids:
+            del self.hash_to_block_ids[hash_value]
+
     # move this block to used list and update all information of the block
     def _allocate_new_block(self, block_id: int, hash: int, token_ids: list[int]) -> Block:
         block = self.blocks[block_id]
@@ -51,11 +63,7 @@ class BlockManager:
         # 上述情况在prefix未连续命中会发生（如prefix的前面一部分被释放了，但是后面还有没被释放的）
         # 因此后面没释放的也不能命中，要新allocate block，但是这些block会计算出hash map中已有的hash值，改变block id指向
         old_hash = block.hash
-        if (
-            old_hash != -1
-            and self.hash_to_block_id.get(old_hash) == block_id
-        ):
-            del self.hash_to_block_id[old_hash]
+        self._unregister_hash(old_hash, block_id)
         block.reset()
         self.free_block_ids.remove(block_id)
         self.used_block_ids.add(block_id)
@@ -72,7 +80,7 @@ class BlockManager:
         block.ref_count += 1
         return block
 
-    # not reset block information and hash_to_block_id for inter-request prefix caching
+    # Keep block contents and hash indexes for inter-request prefix caching.
     def _deallocate_block(self, block_id: int) -> None:
         assert self.blocks[block_id].ref_count == 0, "Block is still in use"
         block = self.blocks[block_id]
@@ -93,13 +101,18 @@ class BlockManager:
         for i in range(max_cacheable_blocks):
             token_ids = seq.block(i)
             h = self.compute_hash(token_ids, h)
-            block_id = self.hash_to_block_id.get(h)
-            if block_id is None:
+            block_ids = self.hash_to_block_ids.get(h)
+            if not block_ids:
                 break
-
-            block = self.blocks[block_id]
-            if block.token_ids != token_ids:  # hash collision
+            matching_blocks = [
+                self.blocks[block_id]
+                for block_id in block_ids
+                if self.blocks[block_id].token_ids == token_ids
+            ]
+            if not matching_blocks:  # hash collision
                 break
+            # Sharing an in-use block consumes no free block, so prefer it.
+            block = max(matching_blocks, key=lambda candidate: candidate.ref_count > 0)
             hit_blocks.append(block)
 
         return hit_blocks
@@ -115,6 +128,10 @@ class BlockManager:
         num_shared_hit_blocks = sum(block.ref_count > 0 for block in hit_blocks)
         num_required_free_blocks = seq.num_blocks - num_shared_hit_blocks
         return len(self.free_block_ids) >= num_required_free_blocks
+
+    def get_num_cached_tokens(self, seq: Sequence) -> int:
+        """Return the reusable prefix length without mutating the sequence."""
+        return len(self._get_prefix_hit_blocks(seq)) * self.block_size
 
 
     def allocate(self, seq: Sequence) -> None:
@@ -137,8 +154,7 @@ class BlockManager:
                 continue
             # cache miss
             block = self._allocate_new_block(self.free_block_ids[0], h, token_ids)
-            if h != -1:
-                self.hash_to_block_id[h] = block.block_id
+            self._register_hash(h, block.block_id)
             seq.block_table.append(block.block_id)
         
     def deallocate(self, seq: Sequence) -> None:
@@ -173,7 +189,7 @@ class BlockManager:
             h = self.compute_hash(token_ids = token_ids, prefix_hash_value = -1 if len(block_tables) == 1 else self.blocks[block_tables[-2]].hash)
             block = self.blocks[last_block_for_seq_id]
             block.update(h=h, token_ids=seq.block(seq.num_blocks - 1))
-            self.hash_to_block_id[h] = block.block_id
+            self._register_hash(h, block.block_id)
         # if one new block is needed
         elif seq.num_tokens % self.block_size == 1:
             # Previous block should be finalized

--- a/src/myvllm/engine/block_manager.py
+++ b/src/myvllm/engine/block_manager.py
@@ -43,19 +43,40 @@ class BlockManager:
         h.update(np.array(token_ids, dtype=np.int32).tobytes())
         return h.intdigest()
 
-    # move this block to used list
-    def _allocate_block(self, block_id: int) -> Block:
+    # move this block to used list and update all information of the block
+    def _allocate_new_block(self, block_id: int, hash: int, token_ids: list[int]) -> Block:
         block = self.blocks[block_id]
         assert block.ref_count == 0, "Block is already allocated"
+        # 防止出现old_hash已经映射到其他的block上了导致误删
+        # 上述情况在prefix未连续命中会发生（如prefix的前面一部分被释放了，但是后面还有没被释放的）
+        # 因此后面没释放的也不能命中，要新allocate block，但是这些block会计算出hash map中已有的hash值，改变block id指向
+        old_hash = block.hash
+        if (
+            old_hash != -1
+            and self.hash_to_block_id.get(old_hash) == block_id
+        ):
+            del self.hash_to_block_id[old_hash]
         block.reset()
         self.free_block_ids.remove(block_id)
         self.used_block_ids.add(block_id)
+        block.update(hash, token_ids)
+        block.ref_count += 1
         return block
 
+    # move this block to used list and change ref_count only
+    def _allocate_hit_block(self, block_id: int) -> Block:
+        block = self.blocks[block_id]
+        assert block.ref_count == 0, "Block is already allocated"
+        self.free_block_ids.remove(block_id)
+        self.used_block_ids.add(block_id)
+        block.ref_count += 1
+        return block
+
+    # not reset block information and hash_to_block_id for inter-request prefix caching
     def _deallocate_block(self, block_id: int) -> None:
         assert self.blocks[block_id].ref_count == 0, "Block is still in use"
         block = self.blocks[block_id]
-        block.token_ids = []
+        # block.token_ids = []
         self.used_block_ids.remove(block_id)
         self.free_block_ids.append(block_id)
 
@@ -66,34 +87,37 @@ class BlockManager:
 
     def allocate(self, seq: Sequence) -> None:
         h = -1
+        prefix_hit = True
+        # KV cache does not contain the logits needed to sample the first
+        # completion token. Keep the last prompt token's block uncached so the
+        # model always runs at least one prompt token during prefill.
+        max_cacheable_blocks = max(0, (seq.num_tokens - 1) // self.block_size)
         for i in range(seq.num_blocks):
-            no_cache_found = False
-
             token_ids = seq.block(i)
             # only compute hash for full blocks, always -1 for partial blocks
             h = self.compute_hash(token_ids=token_ids, prefix_hash_value=h) if len(token_ids) == self.block_size else -1
-            block_id = self.hash_to_block_id.get(h, -1)
-            
-            # if cache miss or hash collision
-            if block_id == -1 or self.blocks[block_id].token_ids != token_ids:
-                no_cache_found = True
+            if prefix_hit and i < max_cacheable_blocks:
+                block_id = self.hash_to_block_id.get(h, -1)
+                # if cache miss or hash collision
+                if block_id == -1 or self.blocks[block_id].token_ids != token_ids:
+                    prefix_hit = False
 
-            if not no_cache_found:
-                # update sequence information
-                seq.num_cached_tokens += self.block_size # which == len(token_ids)
-                # update block information, considering the edge case that the block is not allocated yet but with hash code
-                if block_id not in self.used_block_ids:
-                    block = self._allocate_block(block_id)
-                else:
-                    # update block information
-                    block = self.blocks[self.hash_to_block_id[h]]
-                    block.ref_count += 1
-            else:
-                # cache miss
-                block = self._allocate_block(self.free_block_ids[0])
-                block.update(h=h, token_ids=token_ids)
-                if h != -1:
-                    self.hash_to_block_id[h] = block.block_id
+                if prefix_hit:
+                    # update sequence information
+                    seq.num_cached_tokens += self.block_size # which == len(token_ids)
+                    # prefix of finished request is hitted
+                    if block_id not in self.used_block_ids:
+                        block = self._allocate_hit_block(block_id)
+                    # prefix of on-going request is hitted
+                    else:
+                        block = self.blocks[self.hash_to_block_id[h]]
+                        block.ref_count += 1
+                    seq.block_table.append(block.block_id)
+                    continue
+            # cache miss
+            block = self._allocate_new_block(self.free_block_ids[0], h, token_ids)
+            if h != -1:
+                self.hash_to_block_id[h] = block.block_id
             seq.block_table.append(block.block_id)
         
     def deallocate(self, seq: Sequence) -> None:
@@ -120,10 +144,11 @@ class BlockManager:
     def append(self, seq: Sequence) -> None:
         block_tables = seq.block_table
         last_block_for_seq_id = block_tables[-1]
+        token_ids = seq.block(seq.num_blocks - 1)
 
         # if the last block is now full, compute hash
         if seq.num_tokens % self.block_size == 0:
-            h = self.compute_hash(token_ids = seq.block(seq.num_blocks - 1), prefix_hash_value = -1 if len(block_tables) == 1 else self.blocks[block_tables[-2]].hash)
+            h = self.compute_hash(token_ids = token_ids, prefix_hash_value = -1 if len(block_tables) == 1 else self.blocks[block_tables[-2]].hash)
             block = self.blocks[last_block_for_seq_id]
             block.update(h=h, token_ids=seq.block(seq.num_blocks - 1))
             self.hash_to_block_id[h] = block.block_id
@@ -131,7 +156,7 @@ class BlockManager:
         elif seq.num_tokens % self.block_size == 1:
             # Previous block should be finalized
             assert self.blocks[last_block_for_seq_id].hash != -1
-            block = self._allocate_block(self.free_block_ids[0])
+            block = self._allocate_new_block(self.free_block_ids[0], -1, token_ids)
             block_tables.append(block.block_id)
         # else, do nothing
         else:

--- a/src/myvllm/engine/block_manager.py
+++ b/src/myvllm/engine/block_manager.py
@@ -80,40 +80,61 @@ class BlockManager:
         self.used_block_ids.remove(block_id)
         self.free_block_ids.append(block_id)
 
-    # whether we can allocate a block for this sequence
+    def _get_prefix_hit_blocks(self, seq: Sequence) -> list[Block]:
+        """Return the longest contiguous, reusable prefix of ``seq``.
+
+        The last prompt token must still be computed to produce logits, so the
+        block containing it is deliberately excluded from the cache hit.
+        """
+        h = -1
+        hit_blocks = []
+        max_cacheable_blocks = max(0, (seq.num_tokens - 1) // self.block_size)
+
+        for i in range(max_cacheable_blocks):
+            token_ids = seq.block(i)
+            h = self.compute_hash(token_ids, h)
+            block_id = self.hash_to_block_id.get(h)
+            if block_id is None:
+                break
+
+            block = self.blocks[block_id]
+            if block.token_ids != token_ids:  # hash collision
+                break
+            hit_blocks.append(block)
+
+        return hit_blocks
+
+    # whether we can allocate blocks for this sequence
     def can_allocate(self, seq: Sequence) -> bool:
-        return len(self.free_block_ids) >= seq.num_blocks
+        hit_blocks = self._get_prefix_hit_blocks(seq)
+
+        # A hit on an in-use block only increments its ref_count and therefore
+        # needs no free block. A hit with ref_count == 0 is still in the free
+        # queue; allocating the request removes it from that queue, so it must
+        # remain part of the capacity check.
+        num_shared_hit_blocks = sum(block.ref_count > 0 for block in hit_blocks)
+        num_required_free_blocks = seq.num_blocks - num_shared_hit_blocks
+        return len(self.free_block_ids) >= num_required_free_blocks
 
 
     def allocate(self, seq: Sequence) -> None:
+        hit_blocks = self._get_prefix_hit_blocks(seq)
         h = -1
-        prefix_hit = True
-        # KV cache does not contain the logits needed to sample the first
-        # completion token. Keep the last prompt token's block uncached so the
-        # model always runs at least one prompt token during prefill.
-        max_cacheable_blocks = max(0, (seq.num_tokens - 1) // self.block_size)
         for i in range(seq.num_blocks):
             token_ids = seq.block(i)
             # only compute hash for full blocks, always -1 for partial blocks
             h = self.compute_hash(token_ids=token_ids, prefix_hash_value=h) if len(token_ids) == self.block_size else -1
-            if prefix_hit and i < max_cacheable_blocks:
-                block_id = self.hash_to_block_id.get(h, -1)
-                # if cache miss or hash collision
-                if block_id == -1 or self.blocks[block_id].token_ids != token_ids:
-                    prefix_hit = False
-
-                if prefix_hit:
-                    # update sequence information
-                    seq.num_cached_tokens += self.block_size # which == len(token_ids)
-                    # prefix of finished request is hitted
-                    if block_id not in self.used_block_ids:
-                        block = self._allocate_hit_block(block_id)
-                    # prefix of on-going request is hitted
-                    else:
-                        block = self.blocks[self.hash_to_block_id[h]]
-                        block.ref_count += 1
-                    seq.block_table.append(block.block_id)
-                    continue
+            if i < len(hit_blocks):
+                block = hit_blocks[i]
+                seq.num_cached_tokens += self.block_size
+                # Prefix of a finished request is hit.
+                if block.ref_count == 0:
+                    self._allocate_hit_block(block.block_id)
+                # Prefix of an on-going request is hit.
+                else:
+                    block.ref_count += 1
+                seq.block_table.append(block.block_id)
+                continue
             # cache miss
             block = self._allocate_new_block(self.free_block_ids[0], h, token_ids)
             if h != -1:

--- a/src/myvllm/engine/llm_engine.py
+++ b/src/myvllm/engine/llm_engine.py
@@ -49,7 +49,8 @@ class LLMEngine:
             max_num_batched_tokens=config.get("max_num_batched_tokens", 1024),
             max_cached_blocks=config.get("max_cached_blocks", 1024),
             block_size=config.get("block_size", 256),
-            eos=config.get("eos", 50256)
+            eos=config.get("eos", 50256),
+            max_model_length=config["max_model_length"],
         )
 
         atexit.register(self.exit)

--- a/src/myvllm/engine/llm_engine.py
+++ b/src/myvllm/engine/llm_engine.py
@@ -1,7 +1,10 @@
 import atexit
 import torch.distributed as dist
+import torch
 import time
 import torch.multiprocessing as mp
+import socket
+import uuid
 
 from myvllm.engine.sequence import Sequence
 from myvllm.engine.scheduler import Scheduler
@@ -24,20 +27,50 @@ def worker_process(config, rank, event):
 
 class LLMEngine:
     def __init__(self, config: dict):
-        self.config = config
-        world_size = config.get("world_size", 1)
+        self.config = dict(config)
+        world_size = self.config.get("world_size", 1)
+        if world_size <= 0:
+            raise ValueError("world_size must be greater than 0")
+        if world_size > torch.cuda.device_count():
+            raise ValueError(
+                f"world_size ({world_size}) exceeds available CUDA devices "
+                f"({torch.cuda.device_count()})"
+            )
+        max_position = self.config.get(
+            "max_position", self.config.get("max_position_embeddings")
+        )
+        if max_position is not None and max_position < self.config["max_model_length"]:
+            raise ValueError(
+                f"Rotary embedding capacity ({max_position}) is smaller than "
+                f"max_model_length ({self.config['max_model_length']})"
+            )
+        if "distributed_init_method" not in self.config:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.bind(("127.0.0.1", 0))
+                port = sock.getsockname()[1]
+            self.config["distributed_init_method"] = f"tcp://127.0.0.1:{port}"
+        if world_size > 1:
+            self.config.setdefault(
+                "shared_memory_name", f"myvllm-{uuid.uuid4().hex}"
+            )
         ctx = mp.get_context("spawn")
         self.processes = []
         self.events = []
         for i in range(1, world_size):
             event = ctx.Event()
-            process = ctx.Process(target=worker_process, args=(config, i, event))
+            process = ctx.Process(target=worker_process, args=(self.config, i, event))
             self.events.append(event)
             self.processes.append(process)
             process.start()
         # start the engine only on the master thread with rank = 0
-        self.model_runner = ModelRunner(config, rank=0, event=self.events)
-        self.tokenizer = AutoTokenizer.from_pretrained(config.get("model_name_or_path", "gpt2"))
+        self.model_runner = ModelRunner(self.config, rank=0, event=self.events)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.config.get("model_name_or_path", "gpt2"))
+        configured_eos = self.tokenizer.eos_token_id
+        if configured_eos is None:
+            configured_eos = self.config.get("eos")
+        if configured_eos is None:
+            raise ValueError("Tokenizer/config must provide an EOS token ID")
+        self.config["eos"] = configured_eos
         
         # scheduler needs to init after model_runner: when world_size > 1,
         # ModelRunner.__init__ calls dist.init_process_group() which is a
@@ -45,20 +78,23 @@ class LLMEngine:
         # The scheduler should only be created after that rendezvous completes.
         # When world_size == 1 there is no barrier and no real dependency.
         self.scheduler = Scheduler(
-            max_num_sequences=config.get("max_num_sequences", 16),
-            max_num_batched_tokens=config.get("max_num_batched_tokens", 1024),
-            max_cached_blocks=config.get("max_cached_blocks", 1024),
-            block_size=config.get("block_size", 256),
-            eos=config.get("eos", 50256),
-            max_model_length=config["max_model_length"],
+            max_num_sequences=self.config.get("max_num_sequences", 16),
+            max_num_batched_tokens=self.config.get("max_num_batched_tokens", 1024),
+            max_cached_blocks=self.config.get("max_cached_blocks", 1024),
+            block_size=self.config.get("block_size", 256),
+            eos=configured_eos if configured_eos is not None else self.tokenizer.eos_token_id,
+            max_model_length=self.config["max_model_length"],
         )
 
         atexit.register(self.exit)
 
 
     def exit(self):
-        self.model_runner.call("exit")
-        del self.model_runner
+        if getattr(self, "model_runner", None) is None:
+            return
+        model_runner = self.model_runner
+        self.model_runner = None
+        model_runner.call("exit")
         for process in self.processes:
             process.join()
 
@@ -66,33 +102,39 @@ class LLMEngine:
     # return scheduled sequences and whether it is for prefilling
     # call model_runner.run() to run the model
     # call postprocessor to process the outputs and update sequences and update block manager
-    def step(self) -> tuple[list[int], bool]:
+    def step(self) -> tuple[list[tuple[int, list[int]]], int, bool]:
         scheduled_sequences, is_prefill = self.scheduler.schedule()
         if not scheduled_sequences:
-            return [], is_prefill
+            return [], 0, is_prefill
         # run the model
         outputs = self.model_runner.call("run", scheduled_sequences, is_prefill)
         # Move outputs to CPU and convert them to a list
         if outputs is not None:
             outputs = outputs.cpu().tolist()
+        num_processed_tokens = (
+            sum(len(seq) - seq.num_cached_tokens for seq in scheduled_sequences)
+            if is_prefill else len(scheduled_sequences)
+        )
         # postprocess the outputs
         self.scheduler.postprocess(scheduled_sequences, outputs)
 
         outputs = [(seq.seq_id, seq.completion_token_ids) for seq in scheduled_sequences if seq.is_finished]
-        num_processed_tokens = sum(len(seq) for seq in scheduled_sequences) if is_prefill else len(scheduled_sequences)
 
         return outputs, num_processed_tokens, is_prefill
 
 
     # add prompt string to the waiting queue by first transforming it to Sequence object
     def add_prompt(self, prompt: str, sampling_params: SamplingParams) -> None:
-        self.scheduler.add_sequence(Sequence(token_ids=self.tokenizer.encode(prompt), block_size=self.config['block_size'],sampling_params=sampling_params))
+        token_ids = self.tokenizer.encode(prompt)
+        if not token_ids:
+            raise ValueError("Prompt must contain at least one token")
+        self.scheduler.add_sequence(Sequence(token_ids=token_ids, block_size=self.config['block_size'],sampling_params=sampling_params))
 
     # given a list of prompts
     # add_prompt for each prompt
     # call step until all sequences are finished
     # return the generated texts
-    def generate(self, prompts: list[str], sampling_params: SamplingParams) -> list[str]:
+    def generate(self, prompts: list[str], sampling_params: SamplingParams) -> dict[str, list]:
         for prompt in prompts:
             self.add_prompt(prompt, sampling_params)
         generated_tokens = {}
@@ -108,5 +150,11 @@ class LLMEngine:
             generated_tokens.update({seq_id: tokens for seq_id, tokens in outputs})
 
         generated_tokens = [generated_tokens[seq_id] for seq_id in sorted(generated_tokens.keys())]
-        output = {'text': [self.tokenizer.decode(tokens) for tokens in generated_tokens], 'token_ids': generated_tokens}
+        output = {
+            'text': [
+                self.tokenizer.decode(tokens, skip_special_tokens=True)
+                for tokens in generated_tokens
+            ],
+            'token_ids': generated_tokens,
+        }
         return output

--- a/src/myvllm/engine/model_runner.py
+++ b/src/myvllm/engine/model_runner.py
@@ -23,8 +23,27 @@ class ModelRunner:
         self.enforce_eager = config.get('enforce_eager', False)
 
         self.rank = rank
-        dist.init_process_group('nccl', "tcp://localhost:12345", world_size=config['world_size'], rank=rank)
+        dist.init_process_group(
+            'nccl',
+            config.get('distributed_init_method', "tcp://127.0.0.1:12345"),
+            world_size=config['world_size'],
+            rank=rank,
+        )
         torch.cuda.set_device(rank)
+
+        dtype_config = config.get('dtype', 'bfloat16')
+        if isinstance(dtype_config, str):
+            dtype_name = dtype_config.removeprefix('torch.')
+            dtype_mapping = {
+                'float16': torch.float16,
+                'bfloat16': torch.bfloat16,
+                'float32': torch.float32,
+            }
+            if dtype_name not in dtype_mapping:
+                raise ValueError(f"Unsupported dtype: {dtype_config}")
+            self.default_dtype = dtype_mapping[dtype_name]
+        else:
+            self.default_dtype = dtype_config
 
         # set model
         path_str = self.config['model_name_or_path']
@@ -69,7 +88,7 @@ class ModelRunner:
                 raise Exception(f"Unsupported model: {config['model_name_or_path']}")
 
         # Load weights in GPU (model moved to GPU before loading weights)
-        self.model = self.model.cuda(rank)
+        self.model = self.model.to(device=f'cuda:{rank}', dtype=self.default_dtype)
 
         # Load pretrained weights if model_name_or_path is provided
         if config.get('model_name_or_path'):
@@ -80,9 +99,6 @@ class ModelRunner:
         # self.model = self.model.cuda(rank)
 
         self.sampler = SamplerLayer()
-
-        # Store default dtype before it's needed in allocate_kv_cache
-        self.default_dtype = torch.get_default_dtype()
 
         # Debug flag for first decode step
         self._first_decode = False
@@ -104,20 +120,25 @@ class ModelRunner:
             # Synchronize before setting up shared memory
             dist.barrier()
             if self.rank == 0:
-                # Try to clean up existing shared memory first
-                try:
-                    old_shm = SharedMemory(name='myvllm')
-                    old_shm.close()
-                    old_shm.unlink()
-                except FileNotFoundError:
-                    pass  # Doesn't exist, which is fine
-                self.shm = SharedMemory(name='myvllm', create=True, size=2**20)
+                self.shm_size = config.get(
+                    'shared_memory_size',
+                    max(
+                        2**20,
+                        config['max_num_batched_tokens'] * 16
+                        + config['max_num_sequences'] * 4096,
+                    ),
+                )
+                self.shm = SharedMemory(
+                    name=config['shared_memory_name'],
+                    create=True,
+                    size=self.shm_size,
+                )
                 # Barrier to ensure rank 1 waits until shared memory is created
                 dist.barrier()
             else:
                 # Wait for rank 0 to create shared memory
                 dist.barrier()
-                self.shm = SharedMemory(name='myvllm')
+                self.shm = SharedMemory(name=config['shared_memory_name'])
                 # Don't call self.loop() here - let the spawning code handle it
                 # Otherwise we'll be stuck in an infinite loop during __init__
 
@@ -126,6 +147,8 @@ class ModelRunner:
         assert self.world_size > 1 and self.rank != 0, "read_shm can only be called when world_size > 1 and rank != 0"
         self.event.wait()
         n = int.from_bytes(self.shm.buf[:4], 'little') # read length
+        if n <= 0 or n + 4 > len(self.shm.buf):
+            raise RuntimeError(f"Invalid shared-memory message size: {n}")
         method_name, *args = pickle.loads(self.shm.buf[4:n+4])
         self.event.clear()
         return method_name, args
@@ -137,6 +160,11 @@ class ModelRunner:
         # Flatten: (method_name, args) where args is a tuple -> (method_name, *args)
         data = pickle.dumps((method_name, *args))
         n = len(data)
+        if n + 4 > len(self.shm.buf):
+            raise ValueError(
+                f"Serialized request batch requires {n + 4} bytes, but "
+                f"shared memory has {len(self.shm.buf)} bytes"
+            )
         self.shm.buf[:4] = n.to_bytes(4, 'little')
         self.shm.buf[4:n+4] = data
         for event in self.event:
@@ -165,7 +193,6 @@ class ModelRunner:
             method_name, args = self.read_shm()
             self.call(method_name, *args) # Unpack args when calling
             if method_name == 'exit':
-                self.exit()
                 break
 
     # will be called by both rank == 0 and rank != 0
@@ -186,10 +213,11 @@ class ModelRunner:
     def warmup_model(self):
         torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats()
-        max_tokens = self.config['max_num_batch_tokens']
+        max_tokens = self.config['max_num_batched_tokens']
         max_model_length = self.config['max_model_length']
-        batch_size = max_tokens // max_model_length
-        seqs = [Sequence(token_ids=[0]*max_model_length, block_size=self.config['block_size']) for _ in range(batch_size)]
+        warmup_length = min(max_tokens, max_model_length)
+        batch_size = max(1, max_tokens // warmup_length)
+        seqs = [Sequence(token_ids=[0] * warmup_length, block_size=self.config['block_size']) for _ in range(batch_size)]
         self.run(seqs, is_prefill=True)
         torch.cuda.empty_cache()
 
@@ -244,7 +272,16 @@ class ModelRunner:
         # allocate max possible kv cache for the model, instead for each sequence
         # this is the key for paged attention: one giant KV cache pool, divided into blocks
         # IMPORTANT: Use zeros() instead of empty() to avoid garbage values
-        allocated_kv_cache = torch.zeros(2, self.config['num_layers'], self.config['max_cached_blocks'], self.block_size, num_kv_heads, head_dim, device=f'cuda:{self.rank}')
+        allocated_kv_cache = torch.zeros(
+            2,
+            self.config['num_layers'],
+            self.config['max_cached_blocks'],
+            self.block_size,
+            num_kv_heads,
+            head_dim,
+            device=f'cuda:{self.rank}',
+            dtype=self.default_dtype,
+        )
         layer_id = 0
         for module in self.model.modules():
             if hasattr(module, 'k_cache') and hasattr(module, 'v_cache'):
@@ -343,7 +380,7 @@ class ModelRunner:
         return input_ids    
 
     # prepare the temperature
-    def prepare_sample(self, seqs: list[Sequence]) -> None:
+    def prepare_sample(self, seqs: list[Sequence]) -> torch.Tensor:
         return torch.tensor([seq.temperature for seq in seqs], dtype=torch.float32, pin_memory=True).cuda(non_blocking=True)
 
     # when prefilling, directly compute model forward + logits
@@ -383,7 +420,7 @@ class ModelRunner:
     # run model
     # sample logits
     # reset context
-    def run(self, seqs: list[Sequence], is_prefill: bool) -> list[int]:
+    def run(self, seqs: list[Sequence], is_prefill: bool) -> torch.Tensor | None:
         if is_prefill:
             input_ids = self.prepare_prefill(seqs)
         else:
@@ -404,7 +441,7 @@ class ModelRunner:
     # (later use graph.replay() to run the captured graph)
     @torch.inference_mode()
     def capture_cudagraph(self) -> None:
-        max_bs = self.config['max_num_seqs']
+        max_bs = self.config['max_num_sequences']
         max_len = self.config['max_model_length']
         max_num_blocks = math.ceil(max_len / self.block_size)
         # for decoding, input is always of shape (batch_size, 1)
@@ -417,10 +454,18 @@ class ModelRunner:
         # where to read KV values in the cache
         block_tables = torch.zeros(max_bs, max_num_blocks, dtype=torch.int32, device=f'cuda:{self.rank}')
         # output logits
-        outputs = torch.zeros(max_bs, self.config['vocab_size'], device=f'cuda:{self.rank}')
+        outputs = torch.zeros(
+            max_bs,
+            self.config['hidden_size'],
+            device=f'cuda:{self.rank}',
+            dtype=self.default_dtype,
+        )
 
         # graphs to be captured for different batch sizes
-        batch_sizes = [1, 2, 4, 8] + list(range(16, max_bs + 1, 16))
+        batch_sizes = sorted({
+            bs for bs in [1, 2, 4, 8, max_bs, *range(16, max_bs + 1, 16)]
+            if bs <= max_bs
+        })
         self.graphs = {}
         graph_pool = None
 
@@ -440,8 +485,8 @@ class ModelRunner:
 
             with torch.cuda.graph(graph, graph_pool):
                 outputs[:batch_size] = self.model(input_ids[:batch_size])
-                if graph_pool is None:
-                    graph_pool = graph.pool()
+            if graph_pool is None:
+                graph_pool = graph.pool()
             # store the captured graph
             self.graphs[batch_size] = graph
 

--- a/src/myvllm/engine/scheduler.py
+++ b/src/myvllm/engine/scheduler.py
@@ -4,11 +4,24 @@ from myvllm.engine.block_manager import BlockManager
 
 
 class Scheduler:
-    def __init__(self, max_num_sequences: int, max_num_batched_tokens: int, max_cached_blocks: int, block_size: int, eos: int):
+    def __init__(self, max_num_sequences: int, max_num_batched_tokens: int,
+                 max_cached_blocks: int, block_size: int, eos: int,
+                 max_model_length: int):
+        if max_model_length <= 0:
+            raise ValueError("max_model_length must be greater than 0")
+
+        max_kv_cache_tokens = max_cached_blocks * block_size
+        if max_model_length > max_kv_cache_tokens:
+            raise ValueError(
+                f"max_model_length ({max_model_length}) exceeds the KV cache "
+                f"capacity ({max_kv_cache_tokens} tokens)"
+            )
+
         # block manager
         self.block_manager = BlockManager(max_cached_blocks, block_size)
         self.max_num_batched_tokens = max_num_batched_tokens
         self.max_num_sequences = max_num_sequences
+        self.max_model_length = max_model_length
         # sequence queue
         self.waiting: deque[Sequence] = deque()
         self.running: deque[Sequence] = deque()
@@ -19,6 +32,26 @@ class Scheduler:
         return len(self.waiting) == 0 and len(self.running) == 0
     
     def add_sequence(self, sequence: Sequence):
+        request_max_length = sequence.max_model_length
+        if request_max_length is None:
+            request_max_length = self.max_model_length
+        elif request_max_length > self.max_model_length:
+            raise ValueError(
+                f"Request max_model_length ({request_max_length}) exceeds the "
+                f"engine limit ({self.max_model_length})"
+            )
+        elif request_max_length <= 0:
+            raise ValueError("Request max_model_length must be greater than 0")
+
+        # Prefill must leave room for at least one completion token. We reject
+        # overlong prompts instead of silently dropping their prefix.
+        if sequence.num_prompt_tokens >= request_max_length:
+            raise ValueError(
+                f"Prompt length ({sequence.num_prompt_tokens}) must be smaller "
+                f"than the request context limit ({request_max_length})"
+            )
+
+        sequence.max_model_length = request_max_length
         self.waiting.append(sequence)
 
 

--- a/src/myvllm/engine/scheduler.py
+++ b/src/myvllm/engine/scheduler.py
@@ -26,6 +26,9 @@ class Scheduler:
         self.waiting: deque[Sequence] = deque()
         self.running: deque[Sequence] = deque()
         self.eos = eos
+        # Prefill and decode use different kernels. Alternate when both queues
+        # have work so neither newly arrived prompts nor decodes can starve.
+        self._last_scheduled_prefill = False
 
 
     def is_finished(self):
@@ -50,7 +53,6 @@ class Scheduler:
                 f"Prompt length ({sequence.num_prompt_tokens}) must be smaller "
                 f"than the request context limit ({request_max_length})"
             )
-
         sequence.max_model_length = request_max_length
         self.waiting.append(sequence)
 
@@ -59,18 +61,31 @@ class Scheduler:
         scheduled_sequences = []
         current_scheduled_tokens = 0
         # try schedule for prefilling from waiting queue if not exceeding limits
-        while self.waiting and len(scheduled_sequences) < self.max_num_sequences:
+        try_prefill = self.waiting and (
+            not self.running or not self._last_scheduled_prefill
+        )
+        while try_prefill and self.waiting and len(scheduled_sequences) < self.max_num_sequences:
             seq = self.waiting[0]
-            if self.block_manager.can_allocate(seq) and len(seq) + current_scheduled_tokens <= self.max_num_batched_tokens:
+            num_prefill_tokens = (
+                len(seq) - self.block_manager.get_num_cached_tokens(seq)
+            )
+            if num_prefill_tokens > self.max_num_batched_tokens:
+                raise ValueError(
+                    f"Request needs {num_prefill_tokens} prefill tokens, but "
+                    f"max_num_batched_tokens is {self.max_num_batched_tokens}; "
+                    "chunked prefill is not supported"
+                )
+            if self.block_manager.can_allocate(seq) and num_prefill_tokens + current_scheduled_tokens <= self.max_num_batched_tokens:
                 seq = self.waiting.popleft() # remove from waiting
                 self.block_manager.allocate(seq)
                 seq.status = SequenceStatus.RUNNING
                 self.running.append(seq)
                 scheduled_sequences.append(seq)
-                current_scheduled_tokens += len(seq)
+                current_scheduled_tokens += len(seq) - seq.num_cached_tokens
             else:
                 break
         if scheduled_sequences:
+            self._last_scheduled_prefill = True
             return scheduled_sequences, True
         
         # try schedule for completion from running queue
@@ -96,6 +111,7 @@ class Scheduler:
         # re-add to running queue in the same order
         if scheduled_sequences:
             self.running.extendleft(reversed(scheduled_sequences))
+            self._last_scheduled_prefill = False
 
         return scheduled_sequences, False
 
@@ -109,6 +125,11 @@ class Scheduler:
     # postprocess after generation to check whether sequences are finished
     # if finished, deallocate blocks
     def postprocess(self, seqs: list[Sequence], token_ids: list[int]) -> None:
+        if token_ids is None or len(seqs) != len(token_ids):
+            actual = 0 if token_ids is None else len(token_ids)
+            raise RuntimeError(
+                f"Sampler returned {actual} tokens for {len(seqs)} sequences"
+            )
         for seq, token_id in zip(seqs, token_ids):
             seq.append_token(token_id)
             # Check stopping conditions:

--- a/src/myvllm/engine/sequence.py
+++ b/src/myvllm/engine/sequence.py
@@ -69,8 +69,13 @@ class Sequence:
 
     @property
     def last_block_num_tokens(self):
-        full_blocks = int(math.floor(self.num_tokens / self.block_size))
-        return len(self.token_ids[full_blocks * self.block_size : ])
+        if self.num_tokens == 0:
+            return 0
+        rest_tokens_num = self.num_tokens % self.block_size
+        if rest_tokens_num == 0:
+            return self.block_size
+        else:
+            return rest_tokens_num
 
     def block(self, i):
         assert 0 <= i < self.num_blocks, f"Block index {i} out of range [0, {self.num_blocks})"

--- a/src/myvllm/engine/sequence.py
+++ b/src/myvllm/engine/sequence.py
@@ -14,7 +14,9 @@ class SequenceStatus(Enum):
 class Sequence:
     counter = count()
 
-    def __init__(self, token_ids: list[int], block_size: int, sampling_params = SamplingParams()):
+    def __init__(self, token_ids: list[int], block_size: int, sampling_params=None):
+        if sampling_params is None:
+            sampling_params = SamplingParams()
         self.block_size = block_size # number of tokens per block
         # record sequence id
         self.seq_id = next(Sequence.counter)
@@ -93,6 +95,7 @@ class Sequence:
 
     def __getstate__(self):
         return (
+            self.block_size,
             self.num_tokens, 
             self.num_prompt_tokens, 
             self.num_cached_tokens, 
@@ -102,6 +105,7 @@ class Sequence:
 
     def __setstate__(self, state):
         (
+            self.block_size,
             self.num_tokens,
             self.num_prompt_tokens,
             self.num_cached_tokens,

--- a/src/myvllm/layers/attention.py
+++ b/src/myvllm/layers/attention.py
@@ -112,10 +112,17 @@ def store_kvcache(
 def flash_attention_varlen_kernel(
     Q, K, V, O,
     cu_seqlens_q_ptr,
+    cu_seqlens_k_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    block_tables_ptr,
     scale,
     num_heads: tl.constexpr,
     num_kv_heads: tl.constexpr,
     head_dim: tl.constexpr,
+    block_size: tl.constexpr,
+    max_num_blocks: tl.constexpr,
+    USE_PAGED_KV: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
@@ -134,10 +141,16 @@ def flash_attention_varlen_kernel(
     # Load sequence boundaries
     seq_start = tl.load(cu_seqlens_q_ptr + seq_idx)
     seq_end = tl.load(cu_seqlens_q_ptr + seq_idx + 1)
-    seq_len = seq_end - seq_start
+    seq_len_q = seq_end - seq_start
+    seq_start_k = tl.load(cu_seqlens_k_ptr + seq_idx)
+    seq_end_k = tl.load(cu_seqlens_k_ptr + seq_idx + 1)
+    seq_len_k = seq_end_k - seq_start_k
+    # Prefix-cache hits remove full prefix blocks from Q, while K/V still
+    # represent the full sequence through the paged KV cache.
+    num_cached_tokens = seq_len_k - seq_len_q
     
     # Early exit if this block is beyond sequence length
-    if start_m * BLOCK_M >= seq_len:
+    if start_m * BLOCK_M >= seq_len_q:
         return
     
     # Offset for this block of queries
@@ -148,7 +161,7 @@ def flash_attention_varlen_kernel(
     q_ptrs = Q + (seq_start + offs_m[:, None]) * num_heads * head_dim + off_h * head_dim + offs_d[None, :]
     
     # Load Q block - shape (BLOCK_M, head_dim)
-    mask_m = offs_m < seq_len
+    mask_m = offs_m < seq_len_q
     q = tl.load(q_ptrs, mask=mask_m[:, None], other=0.0)
     
     # Initialize output accumulators
@@ -157,7 +170,7 @@ def flash_attention_varlen_kernel(
     acc = tl.zeros([BLOCK_M, head_dim], dtype=tl.float32)
     
     # Number of blocks to process
-    num_blocks = tl.cdiv(seq_len, BLOCK_N)
+    num_blocks = tl.cdiv(seq_len_k, BLOCK_N)
     
     # Loop over K, V blocks
     for block_n in range(num_blocks):
@@ -165,10 +178,31 @@ def flash_attention_varlen_kernel(
         offs_n = start_n + tl.arange(0, BLOCK_N)
         
         # Mask for valid positions
-        mask_n = offs_n < seq_len
+        mask_n = offs_n < seq_len_k
         
-        # K pointers: K has shape (total_tokens, num_kv_heads, head_dim)
-        k_ptrs = K + (seq_start + offs_n[None, :]) * num_kv_heads * head_dim + kv_head_idx * head_dim + offs_d[:, None]
+        if USE_PAGED_KV:
+            # Prefix hit: current K/V were stored into the paged cache before
+            # this kernel launch, so both the cached prefix and new suffix can
+            # be read through the request's block table.
+            logical_block_idx = offs_n // block_size
+            block_offset = offs_n % block_size
+            block_ids = tl.load(
+                block_tables_ptr
+                + seq_idx * max_num_blocks
+                + logical_block_idx,
+                mask=mask_n,
+                other=0,
+            )
+            cache_offsets = (
+                block_ids * block_size * num_kv_heads * head_dim
+                + block_offset * num_kv_heads * head_dim
+                + kv_head_idx * head_dim
+            )
+            k_ptrs = k_cache_ptr + cache_offsets[None, :] + offs_d[:, None]
+        else:
+            # No prefix hit: K is contiguous and has the same sequence layout
+            # as Q.
+            k_ptrs = K + (seq_start + offs_n[None, :]) * num_kv_heads * head_dim + kv_head_idx * head_dim + offs_d[:, None]
         
         # Load K block - shape (head_dim, BLOCK_N)
         k = tl.load(k_ptrs, mask=mask_n[None, :], other=0.0)
@@ -178,7 +212,9 @@ def flash_attention_varlen_kernel(
         qk = qk * scale
         
         # Apply causal mask: only attend to positions <= current position
-        mask_causal = (offs_m[:, None] + seq_start) >= (offs_n[None, :] + seq_start)
+        # offs_m is relative to the uncached suffix, while offs_n is relative
+        # to the full context. Convert Q positions to full-context positions.
+        mask_causal = (num_cached_tokens + offs_m[:, None]) >= offs_n[None, :]
         qk = tl.where(mask_causal & mask_n[None, :], qk, -1e10)
         
         # Online softmax update
@@ -191,7 +227,10 @@ def flash_attention_varlen_kernel(
         acc = acc * alpha[:, None]
         
         # Load V block - shape (BLOCK_N, head_dim)
-        v_ptrs = V + (seq_start + offs_n[:, None]) * num_kv_heads * head_dim + kv_head_idx * head_dim + offs_d[None, :]
+        if USE_PAGED_KV:
+            v_ptrs = v_cache_ptr + cache_offsets[:, None] + offs_d[None, :]
+        else:
+            v_ptrs = V + (seq_start + offs_n[:, None]) * num_kv_heads * head_dim + kv_head_idx * head_dim + offs_d[None, :]
         v = tl.load(v_ptrs, mask=mask_n[:, None], other=0.0)
         
         # Accumulate weighted values
@@ -213,7 +252,12 @@ def flash_attention_prefill(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    cu_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_tables: torch.Tensor | None,
+    block_size: int,
     scale: float,
     num_heads: int,
     num_kv_heads: int,
@@ -226,7 +270,8 @@ def flash_attention_prefill(
         q: (total_tokens, num_heads, head_dim)
         k: (total_tokens, num_kv_heads, head_dim)
         v: (total_tokens, num_kv_heads, head_dim)
-        cu_seqlens: cumulative sequence lengths
+        cu_seqlens_q: cumulative lengths of newly computed query tokens
+        cu_seqlens_k: cumulative lengths of the full KV context
         scale: attention scale factor
     
     Returns:
@@ -257,22 +302,37 @@ def flash_attention_prefill(
         BLOCK_N = 16
     
     # Number of sequences
-    num_seqs = cu_seqlens.shape[0] - 1
+    num_seqs = cu_seqlens_q.shape[0] - 1
     
     # Find max sequence length to determine grid size
-    cu_seqlens_cpu = cu_seqlens.cpu()
+    cu_seqlens_cpu = cu_seqlens_q.cpu()
     max_seq_len = (cu_seqlens_cpu[1:] - cu_seqlens_cpu[:-1]).max().item()
     
     # Calculate grid dimensions - launch all kernels at once
     grid = (triton.cdiv(max_seq_len, BLOCK_M), num_heads, num_seqs)
     
+    use_paged_kv = block_tables is not None
+    # Triton still requires pointer arguments for constexpr-disabled branches.
+    # These placeholders are never dereferenced when USE_PAGED_KV is False.
+    block_tables_ptr = block_tables if use_paged_kv else cu_seqlens_q
+    k_cache_ptr = k_cache if use_paged_kv else k
+    v_cache_ptr = v_cache if use_paged_kv else v
+    max_num_blocks = block_tables.shape[1] if use_paged_kv else 1
+
     flash_attention_varlen_kernel[grid](
         q, k, v, output,
-        cu_seqlens,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        k_cache_ptr,
+        v_cache_ptr,
+        block_tables_ptr,
         scale,
         num_heads=num_heads,
         num_kv_heads=num_kv_heads,
         head_dim=head_dim,
+        block_size=block_size,
+        max_num_blocks=max_num_blocks,
+        USE_PAGED_KV=use_paged_kv,
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
     )
@@ -511,12 +571,26 @@ class Attention(nn.Module):
         if context.is_prefill:
             # Prefill: use flash attention
             # Varlen mode: (total_tokens, num_heads, head_dim)
-            cu_seqlens = context.cu_seqlens_q
-            if cu_seqlens is None:
+            cu_seqlens_q = context.cu_seqlens_q
+            cu_seqlens_k = context.cu_seqlens_k
+            if cu_seqlens_q is None or cu_seqlens_k is None:
                 raise ValueError("cu_seqlens_q must be provided for varlen attention")
             
-            o = flash_attention_prefill(q, k, v, cu_seqlens, scale, 
-                                        self.num_heads, self.num_kv_heads, self.head_dim)
+            o = flash_attention_prefill(
+                q,
+                k,
+                v,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                k_cache,
+                v_cache,
+                context.block_tables,
+                self.block_size,
+                scale,
+                self.num_heads,
+                self.num_kv_heads,
+                self.head_dim,
+            )
             # Output: (total_tokens, num_heads, head_dim) -> (total_tokens, num_heads * head_dim)
             return o.reshape(o.shape[0], self.num_heads * self.head_dim)
         else:

--- a/src/myvllm/layers/layernorm.py
+++ b/src/myvllm/layers/layernorm.py
@@ -16,12 +16,11 @@ class LayerNorm(torch.nn.Module):
     @torch.compile
     def rms_forward(self, x: torch.Tensor) -> torch.Tensor:
         # RMSNorm(x) = (x / sqrt(mean(x²) + ε)) ⊙ γ
-
-        variance = x.pow(2).mean(dim=-1, keepdim=True) + self.eps
-        sqrt_variance = variance.sqrt()
-        x_norm = (x / sqrt_variance * self.weight)
-
-        return x_norm
+        input_dtype = x.dtype
+        x = x.float()
+        variance = x.pow(2).mean(dim=-1, keepdim=True)
+        x = x * torch.rsqrt(variance + self.eps)
+        return (x * self.weight.float()).to(input_dtype)
 
     def residual_rms_forward(self, x: torch.Tensor, residual: torch.Tensor) -> torch.Tensor:
         x = x + residual

--- a/src/myvllm/layers/linear.py
+++ b/src/myvllm/layers/linear.py
@@ -159,6 +159,10 @@ class QKVColumnParallelLinear(ColumnParallelLinear):
     ):
         self.tp_size = dist.get_world_size()
         num_kv_heads = num_kv_heads or num_heads
+        if num_heads % self.tp_size != 0:
+            raise ValueError("num_heads must be divisible by tensor parallel size")
+        if num_kv_heads % self.tp_size != 0:
+            raise ValueError("num_kv_heads must be divisible by tensor parallel size")
         self.head_size = head_size
         self.num_heads = num_heads // self.tp_size
         self.num_kv_heads = num_kv_heads // self.tp_size

--- a/src/myvllm/layers/sampler.py
+++ b/src/myvllm/layers/sampler.py
@@ -13,7 +13,9 @@ class SamplerLayer(nn.Module):
 
     @torch.compile
     def forward(self, logits: torch.Tensor, temperature: torch.Tensor) -> torch.Tensor:
-        logits/= temperature.unsqueeze(-1)
+        # Sampling probabilities should be computed in FP32 even when model
+        # weights and logits use BF16/FP16.
+        logits = logits.float() / temperature.float().unsqueeze(-1)
         probs = torch.softmax(logits, dim=-1)
         sample_tokens = probs.div_(torch.empty_like(probs).exponential_(1).clamp_min_(1e-10)).argmax(dim=-1)
         return sample_tokens

--- a/src/myvllm/models/llama.py
+++ b/src/myvllm/models/llama.py
@@ -156,7 +156,7 @@ class LlamaDecoderLayer(nn.Module):
     ):
         super().__init__()
         gamma = torch.ones(hidden_size)
-        self.input_layernorm = LayerNorm(gamma)
+        self.input_layernorm = LayerNorm(gamma, eps=rms_norm_epsilon)
         self.self_attn = LlamaAttn(
             hidden_size=hidden_size,
             head_dim=head_dim,
@@ -168,7 +168,7 @@ class LlamaDecoderLayer(nn.Module):
             max_position_embeddings=max_position_embeddings,
             block_size=block_size,
         )
-        self.post_attention_layernorm = LayerNorm(gamma)
+        self.post_attention_layernorm = LayerNorm(gamma, eps=rms_norm_epsilon)
         self.mlp = LlamaMLP(
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
@@ -252,7 +252,7 @@ class LlamaModel(nn.Module):
             ) for _ in range(num_layers)
         ])
         gamma = torch.ones(hidden_size)
-        self.norm = LayerNorm(gamma)
+        self.norm = LayerNorm(gamma, eps=rms_norm_epsilon)
 
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
         x = self.embed_tokens(input_ids)

--- a/src/myvllm/models/qwen3.py
+++ b/src/myvllm/models/qwen3.py
@@ -2,6 +2,24 @@ from myvllm.layers import *
 import torch 
 import torch.nn as nn
 
+
+def get_qwen_positions(context, device: torch.device, num_tokens: int) -> torch.Tensor:
+    if context.is_prefill and context.cu_seqlens_q is not None:
+        cu_q = context.cu_seqlens_q
+        cu_k = context.cu_seqlens_k
+        query_lens = cu_q[1:] - cu_q[:-1]
+        cached_lens = (cu_k[1:] - cu_k[:-1]) - query_lens
+        query_starts = torch.repeat_interleave(cu_q[:-1], query_lens)
+        cached_starts = torch.repeat_interleave(cached_lens, query_lens)
+        return (
+            torch.arange(num_tokens, device=device)
+            - query_starts.to(device=device)
+            + cached_starts.to(device=device)
+        ).long()
+    if context.is_prefill:
+        return torch.arange(num_tokens, device=device)
+    return context.context_lens - 1
+
 # Qwen3Attention: 
 # qkv projection
 # if not qkv_bias: then rms_norm
@@ -25,10 +43,16 @@ class Qwen3Attention(nn.Module):
         super().__init__()
         self.tp_size = dist.get_world_size()
 
+        if num_heads % self.tp_size != 0:
+            raise ValueError("num_heads must be divisible by tensor parallel size")
+        total_num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        if total_num_kv_heads % self.tp_size != 0:
+            raise ValueError("num_kv_heads must be divisible by tensor parallel size")
+
         self.total_num_heads = num_heads
         self.num_heads = num_heads // self.tp_size
 
-        self.total_num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        self.total_num_kv_heads = total_num_kv_heads
         # self.num_kv_heads is per-GPU value (divided by tp_size)
         self.num_kv_heads = self.total_num_kv_heads // self.tp_size
 
@@ -47,8 +71,8 @@ class Qwen3Attention(nn.Module):
         self.qkv_bias = qkv_bias
 
         # Q and K norms as used in Qwen3
-        self.q_norm = LayerNorm(torch.ones(head_dim))
-        self.k_norm = LayerNorm(torch.ones(head_dim))
+        self.q_norm = LayerNorm(torch.ones(head_dim), eps=rms_norm_epsilon)
+        self.k_norm = LayerNorm(torch.ones(head_dim), eps=rms_norm_epsilon)
 
         self.rotary_emb = RotaryEmbedding(
             base=base,
@@ -177,7 +201,7 @@ class Qwen3DecoderLayer(nn.Module):
     ):
         super().__init__()
         gamma = torch.ones(hidden_size)
-        self.input_layernorm = LayerNorm(gamma)
+        self.input_layernorm = LayerNorm(gamma, eps=rms_norm_epsilon)
         self.self_attn = Qwen3Attention(
             hidden_size=hidden_size,
             num_heads=num_heads,
@@ -190,7 +214,7 @@ class Qwen3DecoderLayer(nn.Module):
             max_position=max_position,
             block_size=block_size,
         )
-        self.post_attention_layernorm = LayerNorm(gamma)
+        self.post_attention_layernorm = LayerNorm(gamma, eps=rms_norm_epsilon)
         self.mlp = Qwen3MLP(
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
@@ -206,20 +230,9 @@ class Qwen3DecoderLayer(nn.Module):
         # Compute positions based on context (respecting sequence boundaries for batched prefill)
         from myvllm.utils import get_context
         context = get_context()
-        if context.is_prefill and context.cu_seqlens_q is not None:
-            # For batched prefill, create positions that restart at 0 for each sequence
-            positions = []
-            cu_seqlens = context.cu_seqlens_q.cpu().tolist()
-            for i in range(len(cu_seqlens) - 1):
-                seq_len = cu_seqlens[i+1] - cu_seqlens[i]
-                positions.extend(range(seq_len))
-            positions = torch.tensor(positions, dtype=torch.long, device=x.device)
-        elif context.is_prefill:
-            # For single sequence prefill, use sequential positions
-            positions = torch.arange(x.size(0), device=x.device)
-        else:
-            # For decode, use context_lens - 1 as positions (current position for each sequence)
-            positions = context.context_lens - 1
+        # Prefix hits remove cached tokens from Q. RoPE positions must still
+        # refer to positions in the full sequence, not restart at zero.
+        positions = get_qwen_positions(context, x.device, x.size(0))
 
         x = self.self_attn(x, positions=positions)
         # Residual connection always on for attention output
@@ -271,7 +284,7 @@ class Qwen3Model(nn.Module):
             ) for _ in range(num_layers)
         ])
         gamma = torch.ones(hidden_size)
-        self.norm = LayerNorm(gamma)
+        self.norm = LayerNorm(gamma, eps=rms_norm_epsilon)
 
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
         x = self.embed_tokens(input_ids)

--- a/src/myvllm/models/qwen3.py
+++ b/src/myvllm/models/qwen3.py
@@ -286,12 +286,17 @@ class Qwen3Model(nn.Module):
 # Qwen3ForCausalLM
 # add lm_head on top of Qwen3Model
 class Qwen3ForCausalLM(nn.Module):
-    packed_module_mapping = {
-        "q_proj": ('q_proj', 'q'),
-        "k_proj": ('k_proj', 'k'),
-        "v_proj": ('v_proj', 'v'),
-        "gate_up": ('gate_up_proj', '0'),
-        "gate_down": ('gate_down_proj', '1'),
+    # target packed module -> (Hugging Face source module, shard id)
+    packed_modules_mapping = {
+        "qkv_projection": [
+            ("q_proj", "q"),
+            ("k_proj", "k"),
+            ("v_proj", "v"),
+        ],
+        "gate_up": [
+            ("gate_proj", 0),
+            ("up_proj", 1),
+        ],
     }
     def __init__(
         self,

--- a/src/myvllm/sampling_parameters.py
+++ b/src/myvllm/sampling_parameters.py
@@ -9,4 +9,9 @@ class SamplingParams:
     max_model_length: int | None = None  # Maximum total sequence length (prompt + completion)
 
     def __post_init__(self):
-        assert self.temperature > 1e-10, "greedy sampling is not permitted"
+        if self.temperature <= 1e-10:
+            raise ValueError("temperature must be greater than 0")
+        if self.max_tokens <= 0:
+            raise ValueError("max_tokens must be greater than 0")
+        if self.max_model_length is not None and self.max_model_length <= 0:
+            raise ValueError("max_model_length must be greater than 0")

--- a/src/myvllm/utils/loader.py
+++ b/src/myvllm/utils/loader.py
@@ -1,214 +1,160 @@
-import torch
-from torch import nn
 import os
+from collections.abc import Iterable, Iterator
+
+import torch
 from safetensors import safe_open
-from transformers import AutoConfig
-import re
+from torch import nn
 
 
-def default_weight_loader(param, weight):
-    """Default weight loader that copies weight data to parameter."""
-    if param.shape != weight.shape:
-        raise ValueError(f"Shape mismatch: param {param.shape} vs weight {weight.shape}")
-    param.data.copy_(weight)
+DEFAULT_PACKED_MODULES_MAPPING = {
+    "qkv_projection": [
+        ("q_proj", "q"),
+        ("k_proj", "k"),
+        ("v_proj", "v"),
+    ],
+    "gate_up": [
+        ("gate_proj", 0),
+        ("up_proj", 1),
+    ],
+}
 
 
-def load_weights_from_checkpoint(model: nn.Module, model_name_or_path: str):
+def default_weight_loader(param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
+    """Copy an unsharded checkpoint tensor into a replicated parameter."""
+    if param.shape != loaded_weight.shape:
+        raise ValueError(
+            f"Shape mismatch: model parameter {tuple(param.shape)} vs "
+            f"checkpoint tensor {tuple(loaded_weight.shape)}"
+        )
+    param.data.copy_(loaded_weight)
+
+
+def _map_weight_name(
+    model: nn.Module, hf_name: str
+) -> tuple[str, str | int | None]:
+    """Map one Hugging Face parameter to this model's packed parameter."""
+    packed_modules_mapping = getattr(
+        model, "packed_modules_mapping", DEFAULT_PACKED_MODULES_MAPPING
+    )
+    for target_module, source_modules in packed_modules_mapping.items():
+        for source_module, shard_id in source_modules:
+            source = f".{source_module}."
+            if source in hf_name:
+                target_name = hf_name.replace(
+                    source, f".{target_module}.", 1
+                )
+                return target_name, shard_id
+    return hf_name, None
+
+
+def load_weights(
+    model: nn.Module,
+    weights: Iterable[tuple[str, torch.Tensor]],
+) -> set[str]:
+    """Load Hugging Face tensors, using each parameter's weight loader.
+
+    Packed checkpoint tensors such as q_proj/k_proj/v_proj are passed to the
+    same target parameter one at a time. Its custom weight_loader selects the
+    current tensor-parallel rank's shard and writes it into the correct packed
+    region.
     """
-    Load weights from a Hugging Face model checkpoint into the custom model.
-    Handles QKV and gate_up weight merging for optimized layers.
+    params = dict(model.named_parameters(remove_duplicate=False))
+    loaded_names: set[str] = set()
+    loaded_param_ids: set[int] = set()
+    unexpected_names: list[str] = []
 
-    Args:
-        model: The target model to load weights into
-        model_name_or_path: Path to local checkpoint or Hugging Face model name
-    """
+    for hf_name, loaded_weight in weights:
+        target_name, shard_id = _map_weight_name(model, hf_name)
+        param = params.get(target_name)
+        if param is None:
+            unexpected_names.append(hf_name)
+            continue
+
+        weight_loader = getattr(param, "weight_loader", default_weight_loader)
+        try:
+            if shard_id is None:
+                weight_loader(param, loaded_weight)
+            else:
+                weight_loader(param, loaded_weight, shard_id)
+        except Exception as error:
+            raise RuntimeError(
+                f"Failed to load '{hf_name}' into '{target_name}'"
+            ) from error
+
+        loaded_names.add(target_name)
+        loaded_param_ids.add(id(param))
+
+    missing_names = [
+        name for name, param in params.items()
+        if id(param) not in loaded_param_ids
+    ]
+    if unexpected_names or missing_names:
+        messages = []
+        if unexpected_names:
+            messages.append(
+                "checkpoint tensors without a model parameter: "
+                + ", ".join(unexpected_names[:10])
+            )
+        if missing_names:
+            messages.append(
+                "model parameters without a checkpoint tensor: "
+                + ", ".join(missing_names[:10])
+            )
+        raise RuntimeError("Weight loading is incomplete; " + "; ".join(messages))
+
+    return loaded_names
+
+
+def _resolve_checkpoint_path(model_name_or_path: str) -> str:
+    path = os.path.expanduser(model_name_or_path)
+    if os.path.isdir(path):
+        return path
+
     from huggingface_hub import snapshot_download
 
-    # Try to resolve the path - could be local or from HF cache
-    checkpoint_path = None
+    try:
+        return snapshot_download(
+            repo_id=model_name_or_path,
+            allow_patterns=["*.safetensors", "*.json"],
+            ignore_patterns=["*.msgpack", "*.h5", "*.bin"],
+        )
+    except Exception as error:
+        raise ValueError(
+            f"Could not find or download model '{model_name_or_path}'"
+        ) from error
 
-    # First, try local paths
-    if model_name_or_path.startswith('~'):
-        checkpoint_path = os.path.expanduser(model_name_or_path)
-    elif os.path.isdir(model_name_or_path):
-        checkpoint_path = model_name_or_path
 
-    # If not a local path, try to download from HuggingFace
-    if checkpoint_path is None or not os.path.exists(checkpoint_path):
-        try:
-            checkpoint_path = snapshot_download(
-                repo_id=model_name_or_path,
-                allow_patterns=["*.safetensors", "*.json"],
-                ignore_patterns=["*.msgpack", "*.h5", "*.bin"]  # Skip non-safetensors weights
-            )
-        except Exception as e:
-            raise ValueError(
-                f"Could not find or download model '{model_name_or_path}'. "
-                f"Error: {e}\n"
-                f"Please ensure the model name is correct or provide a valid local path."
-            )
-
-    if not os.path.exists(checkpoint_path):
-        raise ValueError(f"Checkpoint path not found: {checkpoint_path}")
-
-    # Load all safetensors files in the checkpoint directory
-    safetensor_files = [f for f in os.listdir(checkpoint_path) if f.endswith('.safetensors')]
-
+def _iter_safetensor_weights(checkpoint_path: str) -> Iterator[tuple[str, torch.Tensor]]:
+    safetensor_files = sorted(
+        file_name for file_name in os.listdir(checkpoint_path)
+        if file_name.endswith(".safetensors")
+    )
     if not safetensor_files:
         raise ValueError(f"No .safetensors files found in {checkpoint_path}")
 
-    # Collect all weights from HF model
-    hf_weights = {}
-    for file in sorted(safetensor_files):
-        file_path = os.path.join(checkpoint_path, file)
-        with safe_open(file_path, framework='pt', device='cpu') as f:
-            for weight_name in f.keys():
-                hf_weights[weight_name] = f.get_tensor(weight_name)
+    seen_names: set[str] = set()
+    for file_name in safetensor_files:
+        file_path = os.path.join(checkpoint_path, file_name)
+        with safe_open(file_path, framework="pt", device="cpu") as checkpoint:
+            for weight_name in checkpoint.keys():
+                if weight_name in seen_names:
+                    raise ValueError(
+                        f"Duplicate checkpoint tensor '{weight_name}'"
+                    )
+                seen_names.add(weight_name)
+                yield weight_name, checkpoint.get_tensor(weight_name)
 
-    # Now map and load weights into custom model
-    loaded_params = set()
-    skipped_params = []
 
-    # Process each HF weight
-    for hf_name, hf_weight in hf_weights.items():
-        try:
-            # 1. Handle QKV merge (q_proj + k_proj + v_proj → qkv_projection)
-            if '.self_attn.q_proj.weight' in hf_name:
-                layer_match = re.search(r'layers\.(\d+)', hf_name)
-                if layer_match:
-                    layer_idx = layer_match.group(1)
-                    k_name = hf_name.replace('q_proj', 'k_proj')
-                    v_name = hf_name.replace('q_proj', 'v_proj')
-
-                    if k_name in hf_weights and v_name in hf_weights:
-                        q_weight = hf_weight
-                        k_weight = hf_weights[k_name]
-                        v_weight = hf_weights[v_name]
-
-                        # Concatenate q, k, v along output dimension
-                        qkv_weight = torch.cat([q_weight, k_weight, v_weight], dim=0)
-
-                        custom_name = f"model.layers.{layer_idx}.self_attn.qkv_projection.weight"
-                        try:
-                            param = model.get_parameter(custom_name)
-                            param.data.copy_(qkv_weight)
-                            loaded_params.add(custom_name)
-                            loaded_params.add(hf_name)
-                            loaded_params.add(k_name)
-                            loaded_params.add(v_name)
-                        except AttributeError:
-                            skipped_params.append((custom_name, "Parameter not found"))
-
-            # 2. Handle gate_up merge (gate_proj + up_proj → gate_up)
-            elif '.mlp.gate_proj.weight' in hf_name:
-                layer_match = re.search(r'layers\.(\d+)', hf_name)
-                if layer_match:
-                    layer_idx = layer_match.group(1)
-                    up_name = hf_name.replace('gate_proj', 'up_proj')
-
-                    if up_name in hf_weights:
-                        gate_weight = hf_weight
-                        up_weight = hf_weights[up_name]
-
-                        # Concatenate gate and up along output dimension
-                        gate_up_weight = torch.cat([gate_weight, up_weight], dim=0)
-
-                        custom_name = f"model.layers.{layer_idx}.mlp.gate_up.weight"
-                        try:
-                            param = model.get_parameter(custom_name)
-                            param.data.copy_(gate_up_weight)
-                            loaded_params.add(custom_name)
-                            loaded_params.add(hf_name)
-                            loaded_params.add(up_name)
-                        except AttributeError:
-                            skipped_params.append((custom_name, "Parameter not found"))
-
-            # 3. Handle gate_up merge for bias (if present)
-            elif '.mlp.gate_proj.bias' in hf_name:
-                layer_match = re.search(r'layers\.(\d+)', hf_name)
-                if layer_match:
-                    layer_idx = layer_match.group(1)
-                    up_bias_name = hf_name.replace('gate_proj', 'up_proj')
-
-                    if up_bias_name in hf_weights:
-                        gate_bias = hf_weight
-                        up_bias = hf_weights[up_bias_name]
-                        gate_up_bias = torch.cat([gate_bias, up_bias], dim=0)
-
-                        custom_name = f"model.layers.{layer_idx}.mlp.gate_up.bias"
-                        try:
-                            param = model.get_parameter(custom_name)
-                            param.data.copy_(gate_up_bias)
-                            loaded_params.add(custom_name)
-                            loaded_params.add(hf_name)
-                            loaded_params.add(up_bias_name)
-                        except AttributeError:
-                            skipped_params.append((custom_name, "Parameter not found"))
-
-            # 4. Skip k_proj, v_proj, up_proj (already merged)
-            elif any(x in hf_name for x in ['.k_proj.', '.v_proj.', '.up_proj.']):
-                if hf_name not in loaded_params:
-                    skipped_params.append((hf_name, "Merged into qkv_projection or gate_up"))
-
-            # 5. All other parameters: load directly (names match HF)
-            else:
-                try:
-                    param = model.get_parameter(hf_name)
-                    if param.shape != hf_weight.shape:
-                        # Handle vocab size mismatch for embeddings/lm_head
-                        if len(param.shape) > 0 and len(hf_weight.shape) > 0:
-                            min_size = min(param.shape[0], hf_weight.shape[0])
-                            param.data[:min_size].copy_(hf_weight[:min_size])
-                        else:
-                            param.data.copy_(hf_weight)
-                    else:
-                        param.data.copy_(hf_weight)
-                    loaded_params.add(hf_name)
-                except AttributeError:
-                    skipped_params.append((hf_name, "Parameter not found"))
-
-        except Exception as e:
-            skipped_params.append((hf_name, f"Error: {str(e)}"))
-
-    # Check for model parameters that weren't loaded
-    unloaded_params = []
-    for name, param in model.named_parameters():
-        if name not in loaded_params:
-            unloaded_params.append(name)
-
-    print(f"\n{'='*80}")
-    print(f"Weight Loading Summary:")
-    print(f"{'='*80}")
-    print(f"Successfully loaded: {len([p for p in loaded_params if not any(x in p for x in ['.k_proj.', '.v_proj.', '.up_proj.'])])} parameter groups")
-
-    if unloaded_params:
-        print(f"\n⚠️  WARNING: {len(unloaded_params)} model parameters NOT loaded from checkpoint:")
-        for name in unloaded_params[:15]:
-            param = dict(model.named_parameters())[name]
-            print(f"  - {name} (shape: {param.shape}, mean: {param.data.mean():.6f})")
-        if len(unloaded_params) > 15:
-            print(f"  ... and {len(unloaded_params) - 15} more")
-
-    if skipped_params:
-        # Group skipped by reason
-        merged_skips = [s for s in skipped_params if "Merged" in s[1]]
-        not_found_skips = [s for s in skipped_params if "not found" in s[1]]
-        no_mapping_skips = [s for s in skipped_params if "No mapping" in s[1]]
-
-        if merged_skips:
-            print(f"Skipped (merged into other weights): {len(merged_skips)}")
-        if not_found_skips:
-            print(f"Skipped (not found in model): {len(not_found_skips)}")
-            for name, reason in not_found_skips[:5]:
-                print(f"  - {name}")
-            if len(not_found_skips) > 5:
-                print(f"  ... and {len(not_found_skips) - 5} more")
-        if no_mapping_skips:
-            print(f"Skipped (no mapping rule): {len(no_mapping_skips)}")
-            for name, reason in no_mapping_skips[:5]:
-                print(f"  - {name}")
-            if len(no_mapping_skips) > 5:
-                print(f"  ... and {len(no_mapping_skips) - 5} more")
-
-    print(f"{'='*80}")
-    return loaded_params
+def load_weights_from_checkpoint(
+    model: nn.Module, model_name_or_path: str
+) -> set[str]:
+    """Load a local or Hugging Face safetensors checkpoint into ``model``."""
+    checkpoint_path = _resolve_checkpoint_path(model_name_or_path)
+    loaded_names = load_weights(
+        model, _iter_safetensor_weights(checkpoint_path)
+    )
+    print(
+        f"Loaded {len(loaded_names)} model parameters from "
+        f"{model_name_or_path}"
+    )
+    return loaded_names

--- a/tests/test_engine_boundaries.py
+++ b/tests/test_engine_boundaries.py
@@ -1,0 +1,101 @@
+import pickle
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from myvllm.engine.llm_engine import LLMEngine
+from myvllm.engine.block_manager import BlockManager
+from myvllm.engine.sequence import Sequence
+from myvllm.models.qwen3 import get_qwen_positions
+from myvllm.sampling_parameters import SamplingParams
+
+
+def test_sequence_pickle_restores_block_metadata():
+    sequence = Sequence([1, 2, 3], block_size=2)
+    restored = pickle.loads(pickle.dumps(sequence))
+
+    assert restored.block_size == 2
+    assert restored.num_blocks == 2
+    assert restored.last_block_num_tokens == 1
+
+
+def test_duplicate_prefix_hash_keeps_all_valid_block_ids():
+    manager = BlockManager(num_blocks=2, block_size=2)
+    tokens = [1, 2]
+    hash_value = manager.compute_hash(tokens, -1)
+    first = manager._allocate_new_block(0, hash_value, tokens)
+    manager._register_hash(hash_value, first.block_id)
+    second = manager._allocate_new_block(1, hash_value, tokens)
+    manager._register_hash(hash_value, second.block_id)
+
+    manager._unregister_hash(hash_value, second.block_id)
+
+    assert manager.hash_to_block_ids[hash_value] == {first.block_id}
+
+
+def test_prefix_positions_start_after_cached_context():
+    context = SimpleNamespace(
+        is_prefill=True,
+        cu_seqlens_q=torch.tensor([0, 3, 5], dtype=torch.int32),
+        cu_seqlens_k=torch.tensor([0, 7, 13], dtype=torch.int32),
+        context_lens=None,
+    )
+
+    positions = get_qwen_positions(context, torch.device("cpu"), 5)
+
+    assert positions.tolist() == [4, 5, 6, 4, 5]
+
+
+@pytest.mark.parametrize("max_tokens", [0, -1])
+def test_sampling_params_reject_non_positive_max_tokens(max_tokens):
+    with pytest.raises(ValueError, match="max_tokens"):
+        SamplingParams(max_tokens=max_tokens)
+
+
+def test_step_empty_batch_has_consistent_return_shape():
+    engine = object.__new__(LLMEngine)
+    engine.scheduler = SimpleNamespace(schedule=lambda: ([], False))
+
+    assert engine.step() == ([], 0, False)
+
+
+def test_empty_prompt_is_rejected():
+    engine = object.__new__(LLMEngine)
+    engine.tokenizer = SimpleNamespace(encode=lambda prompt: [])
+    engine.config = {"block_size": 4}
+    engine.scheduler = MagicMock()
+
+    with pytest.raises(ValueError, match="at least one token"):
+        engine.add_prompt("", SamplingParams())
+
+
+def test_exit_is_idempotent():
+    engine = object.__new__(LLMEngine)
+    runner = MagicMock()
+    engine.model_runner = runner
+    engine.processes = []
+
+    engine.exit()
+    engine.exit()
+
+    runner.call.assert_called_once_with("exit")
+
+
+def test_generate_skips_special_tokens_when_decoding():
+    engine = object.__new__(LLMEngine)
+    engine.config = {"block_size": 4}
+    engine.tokenizer = MagicMock()
+    engine.tokenizer.encode.return_value = [1]
+    engine.tokenizer.decode.return_value = "answer"
+    engine.scheduler = MagicMock()
+    engine.scheduler.is_finished.side_effect = [False, True]
+    engine.step = MagicMock(return_value=([(0, [10, 11])], 1, False))
+
+    output = engine.generate(["prompt"], SamplingParams())
+
+    assert output["text"] == ["answer"]
+    engine.tokenizer.decode.assert_called_once_with(
+        [10, 11], skip_special_tokens=True
+    )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,118 @@
+import os
+import sys
+
+import torch
+from transformers import Qwen3Config
+from transformers import Qwen3ForCausalLM as HFQwen3ForCausalLM
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from myvllm.models.qwen3 import Qwen3ForCausalLM
+from myvllm.utils.loader import load_weights
+
+
+def test_qwen3_hf_names_use_packed_weight_loaders(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 2)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+
+    model = Qwen3ForCausalLM(
+        vocab_size=8,
+        hidden_size=8,
+        num_heads=4,
+        head_dim=2,
+        num_kv_heads=2,
+        intermediate_size=8,
+        num_layers=1,
+        qkv_bias=False,
+        ffn_bias=False,
+        tie_word_embeddings=True,
+    )
+
+    tensors = {
+        "model.embed_tokens.weight": torch.arange(64, dtype=torch.float32).reshape(8, 8),
+        "model.layers.0.input_layernorm.weight": torch.full((8,), 1.1),
+        "model.layers.0.post_attention_layernorm.weight": torch.full((8,), 1.2),
+        "model.layers.0.self_attn.q_proj.weight": torch.arange(64, dtype=torch.float32).reshape(8, 8),
+        "model.layers.0.self_attn.k_proj.weight": torch.arange(32, dtype=torch.float32).reshape(4, 8) + 100,
+        "model.layers.0.self_attn.v_proj.weight": torch.arange(32, dtype=torch.float32).reshape(4, 8) + 200,
+        "model.layers.0.self_attn.q_norm.weight": torch.full((2,), 1.3),
+        "model.layers.0.self_attn.k_norm.weight": torch.full((2,), 1.4),
+        "model.layers.0.self_attn.o_proj.weight": torch.arange(64, dtype=torch.float32).reshape(8, 8) + 300,
+        "model.layers.0.mlp.gate_proj.weight": torch.arange(64, dtype=torch.float32).reshape(8, 8) + 400,
+        "model.layers.0.mlp.up_proj.weight": torch.arange(64, dtype=torch.float32).reshape(8, 8) + 500,
+        "model.layers.0.mlp.down_proj.weight": torch.arange(64, dtype=torch.float32).reshape(8, 8) + 600,
+        "model.norm.weight": torch.full((8,), 1.5),
+    }
+
+    loaded_names = load_weights(model, tensors.items())
+
+    qkv = model.model.layers[0].self_attn.qkv_projection.weight
+    torch.testing.assert_close(qkv[:4], tensors["model.layers.0.self_attn.q_proj.weight"][4:8])
+    torch.testing.assert_close(qkv[4:6], tensors["model.layers.0.self_attn.k_proj.weight"][2:4])
+    torch.testing.assert_close(qkv[6:8], tensors["model.layers.0.self_attn.v_proj.weight"][2:4])
+
+    gate_up = model.model.layers[0].mlp.gate_up.weight
+    torch.testing.assert_close(gate_up[:4], tensors["model.layers.0.mlp.gate_proj.weight"][4:8])
+    torch.testing.assert_close(gate_up[4:8], tensors["model.layers.0.mlp.up_proj.weight"][4:8])
+
+    torch.testing.assert_close(
+        model.model.layers[0].self_attn.o_proj.weight,
+        tensors["model.layers.0.self_attn.o_proj.weight"][:, 4:8],
+    )
+    torch.testing.assert_close(
+        model.model.layers[0].mlp.down_proj.weight,
+        tensors["model.layers.0.mlp.down_proj.weight"][:, 4:8],
+    )
+    torch.testing.assert_close(
+        model.model.embed_tokens.weight,
+        tensors["model.embed_tokens.weight"][4:8],
+    )
+    assert "model.layers.0.self_attn.qkv_projection.weight" in loaded_names
+    assert "model.layers.0.mlp.gate_up.weight" in loaded_names
+
+
+def test_loads_transformers_qwen3_state_dict(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 1)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+
+    config = Qwen3Config(
+        vocab_size=8,
+        hidden_size=8,
+        intermediate_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=2,
+        tie_word_embeddings=True,
+    )
+    hf_model = HFQwen3ForCausalLM(config)
+    model = Qwen3ForCausalLM(
+        vocab_size=8,
+        hidden_size=8,
+        num_heads=4,
+        head_dim=2,
+        num_kv_heads=2,
+        intermediate_size=8,
+        num_layers=1,
+        qkv_bias=False,
+        ffn_bias=False,
+        tie_word_embeddings=True,
+    )
+
+    hf_weights = hf_model.state_dict()
+    load_weights(model, hf_weights.items())
+
+    qkv = model.model.layers[0].self_attn.qkv_projection.weight
+    expected_qkv = torch.cat([
+        hf_weights["model.layers.0.self_attn.q_proj.weight"],
+        hf_weights["model.layers.0.self_attn.k_proj.weight"],
+        hf_weights["model.layers.0.self_attn.v_proj.weight"],
+    ])
+    torch.testing.assert_close(qkv, expected_qkv)
+
+    gate_up = model.model.layers[0].mlp.gate_up.weight
+    expected_gate_up = torch.cat([
+        hf_weights["model.layers.0.mlp.gate_proj.weight"],
+        hf_weights["model.layers.0.mlp.up_proj.weight"],
+    ])
+    torch.testing.assert_close(gate_up, expected_gate_up)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -7,6 +7,7 @@ from collections import deque
 from unittest.mock import MagicMock
 from myvllm.engine.scheduler import Scheduler
 from myvllm.engine.sequence import Sequence, SequenceStatus
+from myvllm.sampling_parameters import SamplingParams
 
 
 def make_scheduler(
@@ -14,6 +15,7 @@ def make_scheduler(
     max_num_sequences=10,
     max_cached_blocks=100,
     block_size=4,
+    max_model_length=100,
 ):
     return Scheduler(
         max_num_sequences=max_num_sequences,
@@ -21,6 +23,7 @@ def make_scheduler(
         max_cached_blocks=max_cached_blocks,
         block_size=block_size,
         eos=0,
+        max_model_length=max_model_length,
     )
 
 
@@ -46,9 +49,9 @@ class TestBug2TokenLimitBreak:
     """
 
     def _run(self, scheduler: Scheduler):
-        seq_a = Sequence([1, 2, 3])
-        seq_b = Sequence([4, 5, 6])
-        seq_c = Sequence([7, 8, 9])
+        seq_a = Sequence([1, 2, 3], block_size=4)
+        seq_b = Sequence([4, 5, 6], block_size=4)
+        seq_c = Sequence([7, 8, 9], block_size=4)
         inject_running(scheduler, seq_a, seq_b, seq_c)
 
         scheduler.block_manager = MagicMock()
@@ -108,8 +111,8 @@ class TestBug1CanAppendFailure:
     """
 
     def _run(self, scheduler: Scheduler):
-        seq_a = Sequence([1, 2, 3])
-        seq_b = Sequence([4, 5, 6])
+        seq_a = Sequence([1, 2, 3], block_size=4)
+        seq_b = Sequence([4, 5, 6], block_size=4)
         inject_running(scheduler, seq_a, seq_b)
 
         mock_bm = MagicMock()
@@ -146,7 +149,7 @@ class TestBug1CanAppendFailure:
 class TestSchedulerHappyPath:
     def test_prefill_scheduled_first(self):
         scheduler = make_scheduler(max_num_batched_tokens=100, max_cached_blocks=50)
-        seq = Sequence([1, 2, 3, 4])
+        seq = Sequence([1, 2, 3, 4], block_size=4)
         scheduler.add_sequence(seq)
 
         scheduled, is_prefill = scheduler.schedule()
@@ -156,8 +159,8 @@ class TestSchedulerHappyPath:
 
     def test_all_running_seqs_scheduled_when_budget_allows(self):
         scheduler = make_scheduler(max_num_batched_tokens=10)
-        seq_a = Sequence([1])
-        seq_b = Sequence([2])
+        seq_a = Sequence([1], block_size=4)
+        seq_b = Sequence([2], block_size=4)
         inject_running(scheduler, seq_a, seq_b)
 
         scheduler.block_manager = MagicMock()
@@ -174,7 +177,7 @@ class TestSchedulerHappyPath:
     def test_preempt_only_seq_when_cant_append_and_running_empty(self):
         """Original else-branch: running=[seq], can_append=False → preempt seq → waiting."""
         scheduler = make_scheduler()
-        seq = Sequence([1, 2])
+        seq = Sequence([1, 2], block_size=4)
         inject_running(scheduler, seq)
 
         scheduler.block_manager = MagicMock()
@@ -186,3 +189,62 @@ class TestSchedulerHappyPath:
         assert len(scheduled) == 0
         assert seq in scheduler.waiting
         assert seq.status == SequenceStatus.WAITING
+
+
+class TestContextLength:
+    def test_request_inherits_engine_context_limit(self):
+        scheduler = make_scheduler(max_model_length=16)
+        seq = Sequence([1, 2], block_size=4)
+
+        scheduler.add_sequence(seq)
+
+        assert seq.max_model_length == 16
+
+    def test_request_can_choose_a_smaller_context_limit(self):
+        scheduler = make_scheduler(max_model_length=16)
+        params = SamplingParams(max_model_length=8)
+        seq = Sequence([1, 2], block_size=4, sampling_params=params)
+
+        scheduler.add_sequence(seq)
+
+        assert seq.max_model_length == 8
+
+    def test_rejects_prompt_that_leaves_no_generation_room(self):
+        scheduler = make_scheduler(max_model_length=8)
+        seq = Sequence(list(range(8)), block_size=4)
+
+        with pytest.raises(ValueError, match="Prompt length"):
+            scheduler.add_sequence(seq)
+
+    def test_rejects_request_limit_above_engine_limit(self):
+        scheduler = make_scheduler(max_model_length=8)
+        params = SamplingParams(max_model_length=9)
+        seq = Sequence([1], block_size=4, sampling_params=params)
+
+        with pytest.raises(ValueError, match="exceeds the engine limit"):
+            scheduler.add_sequence(seq)
+
+    def test_engine_limit_must_fit_in_kv_cache(self):
+        with pytest.raises(ValueError, match="exceeds the KV cache capacity"):
+            make_scheduler(
+                max_cached_blocks=2,
+                block_size=4,
+                max_model_length=9,
+            )
+
+    def test_generation_stops_at_request_context_limit(self):
+        scheduler = make_scheduler(max_model_length=8)
+        params = SamplingParams(max_tokens=10, max_model_length=4)
+        seq = Sequence([1, 2, 3], block_size=4, sampling_params=params)
+        seq.status = SequenceStatus.RUNNING
+        seq.block_table = [0]
+        scheduler.block_manager.blocks[0].ref_count = 1
+        scheduler.block_manager.free_block_ids.remove(0)
+        scheduler.block_manager.used_block_ids.add(0)
+        scheduler.running.append(seq)
+
+        scheduler.postprocess([seq], [42])
+
+        assert seq.is_finished
+        assert seq.num_tokens == 4
+        assert seq not in scheduler.running

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -248,3 +248,52 @@ class TestContextLength:
         assert seq.is_finished
         assert seq.num_tokens == 4
         assert seq not in scheduler.running
+
+
+class TestPrefillBudget:
+    def test_rejects_uncached_prompt_larger_than_prefill_budget(self):
+        scheduler = make_scheduler(
+            max_num_batched_tokens=2,
+            max_model_length=8,
+        )
+        scheduler.add_sequence(Sequence([1, 2, 3], block_size=4))
+
+        with pytest.raises(ValueError, match="chunked prefill"):
+            scheduler.schedule()
+
+    def test_prefix_hit_counts_only_uncached_tokens(self):
+        scheduler = make_scheduler(
+            max_num_batched_tokens=2,
+            max_cached_blocks=8,
+            block_size=2,
+            max_model_length=8,
+        )
+        cached = Sequence([1, 2, 9], block_size=2)
+        scheduler.block_manager.allocate(cached)
+        scheduler.block_manager.deallocate(cached)
+
+        request = Sequence([1, 2, 3, 4], block_size=2)
+        scheduler.add_sequence(request)
+        scheduled, is_prefill = scheduler.schedule()
+
+        assert is_prefill
+        assert scheduled == [request]
+        assert request.num_cached_tokens == 2
+
+
+class TestSchedulingFairness:
+    def test_alternates_prefill_and_decode_when_both_have_work(self):
+        scheduler = make_scheduler(max_num_batched_tokens=100)
+        running = Sequence([1, 2], block_size=4)
+        scheduler.block_manager.allocate(running)
+        inject_running(scheduler, running)
+        waiting = Sequence([3, 4], block_size=4)
+        scheduler.add_sequence(waiting)
+
+        first, first_is_prefill = scheduler.schedule()
+        assert first_is_prefill
+        assert first == [waiting]
+
+        second, second_is_prefill = scheduler.schedule()
+        assert not second_is_prefill
+        assert set(second) == {running, waiting}


### PR DESCRIPTION
## 1. Fix incorrect last-block token count

Previously, when the sequence length was exactly divisible by the block size, `last_block_num_tokens` returned 0.

For example:

```text
num_tokens = 8
block_size = 4
````

The previous implementation calculated the slice starting at index 8, resulting in an empty list. This also caused:

```python
token_ids[-0:]
```

to return the entire sequence instead of the final block.

The new implementation handles three cases explicitly:

* Empty sequence: return 0
* Full final block: return block_size
* Partial final block: return the remainder

## 2. Fix incorrect block reference counting

Newly allocated blocks previously kept `ref_count == 0`. When the sequence was released, deallocation decremented the reference count to -1, preventing the block from being returned to the free pool correctly.

The allocation logic now initializes every newly allocated or reactivated block with one reference. Cache hits on blocks already in use increment the existing reference count.

## 3. Fix stale hash mappings when recycling blocks

Previously, recycling a cached block could leave its old hash entry in `hash_to_block_id`.

For example:

```text
hash A -> block 3
```

If block 3 was reused for hash B, hash A could still incorrectly point to block 3.

The new allocation path removes the old mapping only when it still points to the recycled block. This avoids both stale mappings and accidental deletion of a mapping that has already been reassigned to another block.

## 4. Fix non-contiguous prefix-cache accounting

Previously, cache lookup continued after an earlier block missed.

For example:

```text
block 0: cache miss
block 1: cache hit
```

The second block could still increase `num_cached_tokens`, even though cached tokens must form a continuous prefix starting from block 0. This could make `ModelRunner` skip tokens that were never actually cached.

The new logic tracks whether the prefix is still continuous. After the first cache miss, all remaining blocks are treated as uncached.

## 5. Fix fully cached prompts producing no logits

If every prompt block was cached, `num_cached_tokens` could equal `num_tokens`. This caused `prepare_prefill()` to pass an empty input to the model.

Although the KV cache contained the prompt’s keys and values, it did not contain the final hidden state or logits required to sample the first completion token.

The number of cacheable blocks is now limited to:

```python
(seq.num_tokens - 1) // block_size
```

This guarantees that the block containing the final prompt token is recomputed, allowing the model to produce the logits needed for the first generated token.

## 6. Fix inconsistent decode-time block initialization

Blocks allocated during decoding previously did not consistently initialize their token metadata and reference count.

Decode-time allocation now uses the same new-block allocation path as prefill, ensuring that block state, token metadata, free/used status, and reference counting remain consistent.

## New Features

### Cross-request prefix caching

Previously, prefix blocks could only be shared while the original request was still running. Once that request finished, its block metadata was cleared, so later requests could not reuse the cached prefix.

Deallocated blocks now retain:

* Their prefix hash
* Their token IDs
* Their KV-cache contents

A block with `ref_count == 0` is treated as an inactive but reusable cache entry. When a later request has the same continuous prefix, the block is moved back into the used set without resetting its cached data.

The allocation logic now distinguishes between:

* Allocating a block for new KV data
* Reactivating a cached block from a completed request
* Sharing a cached block that is still used by another request

This enables prefix-cache reuse both across concurrent requests and across requests that arrive at different times.

