### PR TITLE
fix missing block_size attribute in Sequence object in multiple-gpu inference

### DIFF
--- a/src/myvllm/engine/sequence.py
+++ b/src/myvllm/engine/sequence.py
@@ -91,6 +91,7 @@ class Sequence:
             self.num_prompt_tokens, 
             self.num_cached_tokens, 
             self.block_table,
+            self.block_size,
             self.token_ids if self.num_completion_tokens == 0 else self.last_token
         )
 
@@ -100,6 +101,7 @@ class Sequence:
             self.num_prompt_tokens,
             self.num_cached_tokens,
             self.block_table,
+            self.block_size,
             last_token_or_ids
         ) = state
         # Check if this is prefill (num_completion_tokens == 0) or decode phase


### PR DESCRIPTION
When running `main.py` in multi-gpu environment, I came across an error stating `'Sequence' object has no attribute 'block_size'`. Details of the traceback are as follows:

```text
Traceback (most recent call last):
  File "/root/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/root/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/data-1/zhenghao/LowPrecision/SFT/MinivLLM/src/myvllm/engine/llm_engine.py", line 22, in worker_process
    model_runner.loop()
  File "/home/data-1/zhenghao/LowPrecision/SFT/MinivLLM/src/myvllm/engine/model_runner.py", line 166, in loop
    self.call(method_name, *args) # Unpack args when calling
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/data-1/zhenghao/LowPrecision/SFT/MinivLLM/src/myvllm/engine/model_runner.py", line 179, in call
    return method(*args)
           ^^^^^^^^^^^^^
  File "/home/data-1/zhenghao/LowPrecision/SFT/MinivLLM/src/myvllm/engine/model_runner.py", line 388, in run
    input_ids = self.prepare_prefill(seqs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/data-1/zhenghao/LowPrecision/SFT/MinivLLM/src/myvllm/engine/model_runner.py", line 289, in prepare_prefill
    for i, block_id in enumerate(seq.block_table[seq.num_cached_blocks:]):
                                                 ^^^^^^^^^^^^^^^^^^^^^
  File "/home/data-1/zhenghao/LowPrecision/SFT/MinivLLM/src/myvllm/engine/sequence.py", line 64, in num_cached_blocks
    return int(math.ceil(self.num_cached_tokens / self.block_size))
                                                  ^^^^^^^^^^^^^^^
AttributeError: 'Sequence' object has no attribute 'block_size'
```

I walked through the code and found the error may stem from the interaction with shared memory between the master and sub-threads, as well the `__getstate__` and `__setstate__` functions of `Sequence` object:

In `src/myvllm/engine/model_runner.py`, sub-threads communicate with master thread via `shm`. Current implementation uses `pickle` to manage shared_memory, which saves and constructs Sequence object using `__getstate__` and `setstate__`. However, `block_size` attribute is ignored in these functions, thus when a sub-thread construct `Sequence` object, `block_size` attribute will be missing.

```python
    def __getstate__(self):
        return (
            self.num_tokens, 
            self.num_prompt_tokens, 
            self.num_cached_tokens, 
            self.block_table,
            # self.block_size,
            self.token_ids if self.num_completion_tokens == 0 else self.last_token
        )

    def __setstate__(self, state):
        (
            self.num_tokens,
            self.num_prompt_tokens,
            self.num_cached_tokens,
            self.block_table,
            # self.block_size,
            last_token_or_ids
        ) = state
        # Check if this is prefill (num_completion_tokens == 0) or decode phase
        num_completion_tokens = self.num_tokens - self.num_prompt_tokens
        if num_completion_tokens == 0:
            # Prefill: last_token_or_ids is the full token_ids list
            self.token_ids = last_token_or_ids
        else:
            # Decode: last_token_or_ids is just the last token
            self.token_ids = [last_token_or_ids]
        # Restore last_token attribute
        self.last_token = self.token_ids[-1] if self.token_ids else None
```

The fix is adding `self.block_size` in these two functions:

```python
    def __getstate__(self):
        return (
            self.num_tokens, 
            self.num_prompt_tokens, 
            self.num_cached_tokens, 
            self.block_table,
            self.block_size,
            self.token_ids if self.num_completion_tokens == 0 else self.last_token
        )

    def __setstate__(self, state):
        (
            self.num_tokens,
            self.num_prompt_tokens,
            self.num_cached_tokens,
            self.block_table,
            self.block_size,
            last_token_or_ids
        ) = state
        # Check if this is prefill (num_completion_tokens == 0) or decode phase
        num_completion_tokens = self.num_tokens - self.num_prompt_tokens
        if num_completion_tokens == 0:
            # Prefill: last_token_or_ids is the full token_ids list
            self.token_ids = last_token_or_ids
        else:
            # Decode: last_token_or_ids is just the last token
            self.token_ids = [last_token_or_ids]
        # Restore last_token attribute
        self.last_token = self.token_ids[-1] if self.token_ids else None
```