### PR TITLE
fix(block_manager): never share live blocks — cache hits cannot be consumed and silently corrupt prefill output

### DIFF
--- a/src/myvllm/engine/block_manager.py
+++ b/src/myvllm/engine/block_manager.py
@@ -67,7 +67,8 @@ class BlockManager:
         # ignores context.block_tables, and qwen3 derives RoPE positions from
         # cu_seqlens_q, so both would be wrong by num_cached_tokens. Enabling reuse
         # means a paged prefill kernel (cu_seqlens_q != cu_seqlens_k) plus a position
-        # offset; until then this line is what keeps the engine correct.
+        # offset; until then this line, together with allocate() refusing to share
+        # live blocks, is what keeps the engine correct.
         block.token_ids = []
         self.used_block_ids.remove(block_id)
         self.free_block_ids.append(block_id)
@@ -87,23 +88,22 @@ class BlockManager:
             h = self.compute_hash(token_ids=token_ids, prefix_hash_value=h) if len(token_ids) == self.block_size else -1
             block_id = self.hash_to_block_id.get(h, -1)
             
-            # if cache miss or hash collision
-            if block_id == -1 or self.blocks[block_id].token_ids != token_ids:
+            # A hash hit is only safe on a block no live sequence is using.
+            # Sharing a live block advances num_cached_tokens, but the prefill
+            # path cannot consume cached K/V yet (see the note in
+            # _deallocate_block), so the sequence would silently attend only
+            # over its own new tokens with RoPE positions restarting at 0.
+            if (
+                block_id == -1
+                or block_id in self.used_block_ids
+                or self.blocks[block_id].token_ids != token_ids
+            ):
                 no_cache_found = True
 
             if not no_cache_found:
                 # update sequence information
                 seq.num_cached_tokens += self.block_size # which == len(token_ids)
-                # update block information, considering the edge case that the block is not allocated yet but with hash code
-                if block_id not in self.used_block_ids:
-                    # Unreachable while _deallocate_block clears token_ids: a freed
-                    # block has token_ids == [] and fails the match above. Kept for
-                    # when cross-sequence reuse is enabled.
-                    block = self._allocate_block(block_id)
-                else:
-                    # update block information
-                    block = self.blocks[self.hash_to_block_id[h]]
-                    block.ref_count += 1
+                block = self._allocate_block(block_id)
             else:
                 # cache miss
                 block = self._allocate_block(self.free_block_ids[0])

--- a/tests/test_block_manager.py
+++ b/tests/test_block_manager.py
@@ -1,0 +1,113 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+import pytest
+
+from myvllm.engine.block_manager import BlockManager
+from myvllm.engine.sequence import Sequence, SequenceStatus
+from myvllm.engine.scheduler import Scheduler
+
+
+def make_scheduler(
+    max_num_batched_tokens=100,
+    max_num_sequences=8,
+    max_cached_blocks=64,
+    block_size=4,
+):
+    return Scheduler(
+        max_num_sequences=max_num_sequences,
+        max_num_batched_tokens=max_num_batched_tokens,
+        max_cached_blocks=max_cached_blocks,
+        block_size=block_size,
+        eos=0,
+    )
+
+
+def ref_counts(block_manager):
+    return {b.block_id: b.ref_count for b in block_manager.blocks if b.ref_count > 0}
+
+
+class TestLivePrefixSharing:
+    """
+    Two sequences with an identical, full-block-aligned prefix scheduled in the
+    same prefill batch. BlockManager.allocate() finds the first sequence's live
+    blocks via hash_to_block_id, shares them (ref_count += 1) and advances the
+    second sequence's num_cached_tokens -- but the prefill attention kernel only
+    attends over the K/V computed in that pass and derives RoPE positions from
+    cu_seqlens_q, so a consumed cache hit would silently corrupt the second
+    sequence's output. Until the paged prefill kernel + position offset exist,
+    sharing live blocks must not happen.
+    """
+
+    def _two_identical_seqs(self):
+        tokens = list(range(100, 112))  # 12 tokens / block_size 4 = 3 full blocks
+        return Sequence(tokens, block_size=4), Sequence(tokens, block_size=4)
+
+    def test_no_live_sharing_between_duplicate_prompts(self):
+        scheduler = make_scheduler()
+        seq_a, seq_b = self._two_identical_seqs()
+        scheduler.add_sequence(seq_a)
+        scheduler.add_sequence(seq_b)
+
+        scheduled, is_prefill = scheduler.schedule()
+
+        assert is_prefill
+        assert seq_a in scheduled and seq_b in scheduled
+        assert seq_a.num_cached_tokens == 0, (
+            "seq_a is allocated first and must never consume the prefix cache"
+        )
+        assert seq_b.num_cached_tokens == 0, (
+            "seq_b shared live blocks with seq_a and advanced num_cached_tokens; "
+            "the prefill kernel cannot consume cached K/V, so this silently "
+            "corrupts seq_b's attention output"
+        )
+        assert not set(seq_a.block_table) & set(seq_b.block_table), (
+            "duplicate prompts must not share physical blocks until the prefill "
+            "path can read K/V from the cache"
+        )
+        assert all(count == 1 for count in ref_counts(scheduler.block_manager).values())
+
+    def test_finished_sequence_blocks_are_not_reused(self):
+        # Freed blocks keep their slot but not their content: a later identical
+        # prompt must allocate fresh blocks, not revive freed ones.
+        scheduler = make_scheduler()
+        tokens = list(range(100, 112))
+        seq_a = Sequence(tokens, block_size=4)
+        scheduler.add_sequence(seq_a)
+        scheduler.schedule()
+        scheduler.block_manager.deallocate(seq_a)
+        seq_a.status = SequenceStatus.FINISHED
+
+        seq_b = Sequence(tokens, block_size=4)
+        scheduler.add_sequence(seq_b)
+        scheduled, is_prefill = scheduler.schedule()
+
+        assert is_prefill
+        assert seq_b.num_cached_tokens == 0
+        assert not set(seq_a.block_table) & set(seq_b.block_table)
+
+    def test_oversized_prompt_rejected_up_front(self):
+        scheduler = make_scheduler(max_cached_blocks=2)
+        seq = Sequence(list(range(100, 116)), block_size=4)  # 16 tokens / 4 = 4 blocks > 2
+        with pytest.raises(ValueError):
+            scheduler.add_sequence(seq)
+
+
+class TestBlockAccounting:
+    def test_ref_count_returns_to_zero_after_generation(self):
+        scheduler = make_scheduler()
+        tokens = list(range(100, 112))
+        seq = Sequence(tokens, block_size=4)
+        scheduler.add_sequence(seq)
+        scheduler.schedule()
+
+        # simulate the decode phase appending enough tokens to cross block boundaries
+        for _ in range(8):
+            assert scheduler.block_manager.can_append(seq)
+            scheduler.block_manager.append(seq)
+            seq.append_token(1)
+
+        scheduler.block_manager.deallocate(seq)
+        assert all(b.ref_count == 0 for b in scheduler.block_manager.blocks)
+        assert len(scheduler.block_manager.free_block_ids) == len(scheduler.block_manager.blocks)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -46,9 +46,9 @@ class TestBug2TokenLimitBreak:
     """
 
     def _run(self, scheduler: Scheduler):
-        seq_a = Sequence([1, 2, 3])
-        seq_b = Sequence([4, 5, 6])
-        seq_c = Sequence([7, 8, 9])
+        seq_a = Sequence([1, 2, 3], block_size=4)
+        seq_b = Sequence([4, 5, 6], block_size=4)
+        seq_c = Sequence([7, 8, 9], block_size=4)
         inject_running(scheduler, seq_a, seq_b, seq_c)
 
         scheduler.block_manager = MagicMock()
@@ -108,8 +108,8 @@ class TestBug1CanAppendFailure:
     """
 
     def _run(self, scheduler: Scheduler):
-        seq_a = Sequence([1, 2, 3])
-        seq_b = Sequence([4, 5, 6])
+        seq_a = Sequence([1, 2, 3], block_size=4)
+        seq_b = Sequence([4, 5, 6], block_size=4)
         inject_running(scheduler, seq_a, seq_b)
 
         mock_bm = MagicMock()
@@ -146,7 +146,7 @@ class TestBug1CanAppendFailure:
 class TestSchedulerHappyPath:
     def test_prefill_scheduled_first(self):
         scheduler = make_scheduler(max_num_batched_tokens=100, max_cached_blocks=50)
-        seq = Sequence([1, 2, 3, 4])
+        seq = Sequence([1, 2, 3, 4], block_size=4)
         scheduler.add_sequence(seq)
 
         scheduled, is_prefill = scheduler.schedule()
@@ -156,8 +156,8 @@ class TestSchedulerHappyPath:
 
     def test_all_running_seqs_scheduled_when_budget_allows(self):
         scheduler = make_scheduler(max_num_batched_tokens=10)
-        seq_a = Sequence([1])
-        seq_b = Sequence([2])
+        seq_a = Sequence([1], block_size=4)
+        seq_b = Sequence([2], block_size=4)
         inject_running(scheduler, seq_a, seq_b)
 
         scheduler.block_manager = MagicMock()
@@ -174,7 +174,7 @@ class TestSchedulerHappyPath:
     def test_preempt_only_seq_when_cant_append_and_running_empty(self):
         """Original else-branch: running=[seq], can_append=False → preempt seq → waiting."""
         scheduler = make_scheduler()
-        seq = Sequence([1, 2])
+        seq = Sequence([1, 2], block_size=4)
         inject_running(scheduler, seq)
 
         scheduler.block_manager = MagicMock()


### PR DESCRIPTION
On a cache hit, `BlockManager.allocate()` shares live blocks and sets `num_cached_tokens > 0`, but prefill cannot consume cached K/V: the attention kernel works only on K/V computed in the current pass, and RoPE positions restart at 0 per `cu_seqlens_q`. Duplicate concurrent prompts therefore produce silently corrupted output. This PR treats hits on live blocks as misses, making the prefix cache register-only until a real consumer exists (see #88). Includes a deterministic regression test (fails on main, passes here) and a drive-by fix for tests that currently TypeError on main.

## 问题

两条序列带有相同前缀时，`BlockManager.allocate()` 会把第一条的 KV cache 物理块复用给第二条，并把第二条的 `num_cached_tokens` 记为非零。但 prefill 阶段没有对应的消费逻辑：注意力 kernel 只在本次前向计算出的 K/V 上执行，不会按 `block_table` 从缓存池读取数据；RoPE 位置又按 `cu_seqlens_q` 从 0 重排。结果第二条的输入被截去前缀后，注意力既看不到缓存中的前缀 K/V，位置编码也是错的，输出静默出错（不报错、不崩溃）。尾部 K/V 还会带错误位置写入缓存，decode 阶段继续使用这些数据。

## 触发条件

- 两条序列有完全相同的前缀，且前缀至少覆盖一个完整块（默认 `block_size=256`，即  ≥257 个相同 token）；
- 两条序列生命周期重叠：典型情况是 `generate([P, P])` 进入同一个 prefill 批次，或第二条在第一条仍在生成时提交。

当前演示配置不会触发：`max_model_length=128 < block_size=256`，块永远填不满，哈希表始终为空。`max_model_length` 超过 `block_size`、调小 `block_size`、或提交重复长 prompt后即可触发。

## 复现结果

Qwen3-0.6B，近似贪婪采样以保证确定性。同一条约 300 token 的 prompt：单独生成一次作为对照，再通过 `generate([P, P])` 同批提交两次。

- 第一条输出与对照逐 token 一致，排除批处理引入数值差异；
- 第二条 `num_cached_tokens=256`、与第一条共享物理块，首 token 为 `<|im_start|>` 等异常 token，严重时直接复读 prompt 原文；
- 4 组不同 prompt 均复现；应用本修复后 0 组复现，所有输出与对照一致。

## 修复（临时方案）

`allocate()` 增加一个条件：哈希命中且目标块仍在 `used_block_ids` 中时按 miss 处理。
prefix cache 退化为只登记不消费，`num_cached_tokens` 恒为 0，正确性恢复。同时删除了原注释中标注 "Unreachable" 的死分支。

新增 `tests/test_block_manager.py`，其中活体共享回归测试在 main 上失败、在本分支通过；
顺带修复 `tests/test_scheduler.py` 在 main 上已存在的 8 处 TypeError（`Sequence` 签名变更未同步）。`pytest tests/` 12/12 通过。

## 后续与相关 PR

完整修复需要三点：分页 prefill kernel（按 `block_table` 从缓存池读 K/V，`cu_seqlens_q` 定界输入、`cu_seqlens_k` 定界可见范围）、RoPE 使用绝对位置（从 `num_cached_tokens` 起算）、释放块保留内容以启用跨请求复用。即 #88 的方案，也与上游 nano-vllm 4 月的实现一致；#88 合并后本守卫可整体替换，在此之前它消除当前 main 上已可触发的静默错误。

- #88：已列出相同的两条根因与完整修法，但从功能完善角度撰写，未指出当前 main 可实际触发；7 月 19 日开启至今无人 review。
- #62 / #70 / #75 / #76：同一区域此前的修复（泄漏、崩溃类）。本 bug 同属块管理，但不崩溃、静默出错，因此至今无人报告。
- #60 / #50：此前修复的 ">256 token 哈希计算崩溃"，同一套哈希机制暴露的第一个问题。